### PR TITLE
Therm calcs 25A

### DIFF
--- a/Core/Inc/datastructs.h
+++ b/Core/Inc/datastructs.h
@@ -36,7 +36,7 @@ typedef struct {
 	float open_cell_voltage[NUM_CELLS_PER_CHIP];
 	float cell_voltages[NUM_CELLS_PER_CHIP];
 
-	/* For temperatures of on-board therms.*/
+	/* Maximum temperature of on-board therms.*/
 	float on_board_temp;
 
 	/// temperature of the die

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -9,50 +9,35 @@
 #define OCV_TIMER_DURATION 750 // in ticks
 
 /**
- * @brief Map cells to therms (ra codes).  Note beta has only 6 therms. 
+ * @brief Map cells to therms (ra codes).  Note beta has only 6 therms.
  */
-const int THERM_MAP[NUM_CELLS_PER_CHIP] = { 0, 0, 1, 1, 2, 2, 3,
-					    3, 4, 4, 5, 5, 6 };
+const int THERM_MAP[NUM_CELLS_PER_CHIP] = { 0, 0, 1, 1, 5, 5, 6,
+					    6, 7, 7, 8, 8, 9 };
 
 // clang-format on
 
 /**
  * @brief Calculate the cell temperature of a 10,000 ohm NTP resistor (model 103)
- * 
+ *
  * @param res The resistance of the resistor
  * @return float The temperature
  */
 static float calc_temp(float res)
 {
-	float coef = res / 10000.0;
-	// achieved via passing ThermCalcs.xlsx into https://www.standardsapplied.com/nonlinear-curve-fitting-calculator.html
-	return -1149.531863 * (pow(coef, 1.0 / 8)) +
-	       658.9396848 * (pow(coef, 1.0 / 4)) +
-	       -87.8102815 * (pow(coef, 1.0 / 2)) + 2.034216235 * coef +
-	       601.008351;
+	// achieved via math --  See BMS 25 Mapping and Calcs
+	return ((298.15 * 3462.28) / (298.15 * logf(res / 10100) + 3462.28)) -
+	       273.15;
 }
 
 /**
  * @brief Calculate a cell temperature based on the thermistor reading.
- * 
+ *
  * @param voltage The thremistor reading.
  * @return float The temperature in degrees Celsius.
  */
 static float calc_cell_temp(float voltage)
 {
-	float res = (5600 * (3 - voltage)) / voltage;
-	return calc_temp(res);
-}
-
-/**
- * @brief Calculate a cell temperature of onboard therm
- * 
- * @param voltage the voltage read by ADC
- * @return float The temperature in degrees C
- */
-static float calc_cell_temp_onboard(float voltage)
-{
-	float res = (5600 * (5 - voltage)) / voltage;
+	float res = (voltage * 10000) / (3 - voltage);
 	return calc_temp(res);
 }
 
@@ -77,12 +62,13 @@ void calc_cell_temps(analyzer_t *analyzer, acc_data_t *acc_data)
 		}
 
 		// Calculate onboard therm temps and chip temps
-		analyzer->chip_data[chip].on_board_temp =
-			(calc_cell_temp_onboard(getVoltage(
-				 acc_data->chips[chip].raux.ra_codes[6])) +
-			 calc_cell_temp_onboard(getVoltage(
-				 acc_data->chips[chip].raux.ra_codes[7]))) /
-			2;
+		analyzer->chip_data[chip].on_board_temp = fmaxf(
+			fmaxf(calc_cell_temp(getVoltage(
+				      acc_data->chips[chip].raux.ra_codes[2])),
+			      calc_cell_temp(getVoltage(
+				      acc_data->chips[chip].raux.ra_codes[3]))),
+			calc_cell_temp(getVoltage(
+				acc_data->chips[chip].raux.ra_codes[4])));
 
 		/* set the die temp */
 		// conversion rate from datasheet, Table 105.  also in driver src

--- a/Core/Src/analyzer.c
+++ b/Core/Src/analyzer.c
@@ -37,7 +37,7 @@ static float calc_temp(float res)
  */
 static float calc_cell_temp(float voltage)
 {
-	float res = (voltage * 10000) / (3 - voltage);
+	float res = (10000 * (3 - voltage)) / voltage;
 	return calc_temp(res);
 }
 


### PR DESCRIPTION
## Changes

_Explanation of changes goes here_

Therms calculated.
See https://northeastern.sharepoint.com/:x:/r/sites/northeasternelectricracing/Shared%20Documents/Electrical/25A/BMS/BMS%20Mapping%20and%20Calcs.xlsx?d=w0151a69cfa4c4009bcc1e7794a597742&csf=1&web=1&e=bvDliJ

Switches from linear fit this year to the B value calculation.  Uses the worst case B value, resistor values, etc. to get correct value.  I did not #define stuff because I prefer it to live in this document.

## Notes

_Any other notes go here_

## Test Cases

- Case A
- Edge case
- ...

## To Do

_Any remaining things that need to get done_

- [ ] I think out of scope: This year the therms are in different spots on alpha and beta, so we need to send different on board temperatures and/or all on board temperatures in percell.
- [ ] ...

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
