### PR TITLE
Enable Cycle Counter for TraceX timestamps

### DIFF
--- a/Core/Inc/traceout_app.h
+++ b/Core/Inc/traceout_app.h
@@ -13,6 +13,11 @@
 #if (ENABLE_TRACEX)
 
 /**
+ * @brief Enable CPU cycle counter for TraceX timestamps.
+ */
+void tracex_enable_cycle_counter(void);
+
+/**
  * @brief Initialize TraceX output for the application.
  *
  * Sets up the trace buffer, transport, and required MCU features.

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -72,6 +72,7 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   /* USER CODE BEGIN App_ThreadX_Init */
 #if (ENABLE_TRACEX)
   TraceOut_AppInit();
+  tracex_enable_cycle_counter();
   tracex_start();
 #endif
   CATCH_ERROR(queues_init(byte_pool), U_SUCCESS);

--- a/Core/Src/traceout_app.c
+++ b/Core/Src/traceout_app.c
@@ -49,6 +49,18 @@ static void uart_tx_start(const uint8_t *data, uint16_t len)
 
 /*************** Public API ***************/
 
+void tracex_enable_cycle_counter(void)
+{
+	/* Enable trace and debug block so DWT can be used */
+	CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+
+	/* Reset the cycle counter */
+	DWT->CYCCNT = 0U;
+
+	/* Start the DWT cycle counter */
+	DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+}
+
 void TraceOut_AppInit(void)
 {
 	tracex_init(s_trace_buffer, sizeof(s_trace_buffer));


### PR DESCRIPTION
## Changes

Enabled cycle counter for tracex timestamps.

## Checklist

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack