### PR TITLE
fixing average voltage readings from segment

### DIFF
--- a/Core/Inc/bms_config.h
+++ b/Core/Inc/bms_config.h
@@ -6,11 +6,11 @@
 
 // Hardware definition
 #define NUM_SEGMENTS	   1
-#define NUM_CHIPS	   NUM_SEGMENTS * 2
+#define NUM_CHIPS	   (NUM_SEGMENTS * 2)
 #define NUM_CELLS_PER_CHIP 13
-#define NUM_CELLS	   NUM_CELLS_PER_CHIP *NUM_CHIPS
+#define NUM_CELLS	   (NUM_CELLS_PER_CHIP * NUM_CHIPS)
 // only actual flexPCB therms counted
-#define NUM_THERMS		    7 * NUM_CHIPS
+#define NUM_THERMS		    (7 * NUM_CHIPS)
 #define NUM_ONBOARD_THERMS_PER_CHIP 3
 
 // Firmware limits

--- a/Core/Inc/shep_tasks.h
+++ b/Core/Inc/shep_tasks.h
@@ -7,7 +7,7 @@
 
 // #define DEBUG_HV_PLATE
 #define DEBUG_VOLTAGES
-// #define DEBUG_TEMPS
+#define DEBUG_TEMPS
 // #define DEBUG_AlGOS
 
 /* Initializes all ThreadX threads.


### PR DESCRIPTION
## Changes

Added parantheses to fix operator precedence when using `#define`

## Test Cases

- Test on segment

## Checklist

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack