### PR TITLE
send individual shutdown GPIO states over CAN 0x95

### DIFF
--- a/Core/Inc/can_messages_rx.h
+++ b/Core/Inc/can_messages_rx.h
@@ -15,24 +15,6 @@
 #include "bitstream.h"
 
 typedef struct {
- float current_target_ac;
-} ac_current_command_t;
-
-void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command);
-
-typedef struct {
- float brake_ac_current;
-} brake_current_command_t;
-
-void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command);
-
-typedef struct {
- uint8_t drive_enable;
-} drive_enable_command_t;
-
-void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command);
-
-typedef struct {
  uint8_t pwm_duty;
 } shepherd_bms_fan_percent_t;
 
@@ -109,6 +91,180 @@ typedef struct {
 } rtds_command_message_t;
 
 void receive_rtds_command_message(const can_msg_t *message, rtds_command_message_t *rtds_command_message);
+
+typedef struct {
+ uint8_t button_id;
+} wheel_buttons_t;
+
+void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons);
+
+typedef struct {
+ uint16_t R_iso_corrected;
+ uint8_t R_iso_status;
+ uint8_t Iso_measurement_counter;
+ bool device_error;
+ bool HV_pos_conn_fail;
+ bool HV_neg_conn_fail;
+ bool Earth_conn_fail;
+ bool Iso_alarm;
+ bool iso_warning;
+ bool iso_outdated;
+ bool Unbalance_alarm;
+ bool Undervoltage_alarm;
+ bool Unsafe_to_start;
+ bool Earthlift_Open;
+ uint8_t warnings_and_alarms_unused_bits;
+ uint8_t Device_Activity;
+ uint8_t Not_Applicable;
+} imd_general_information_t;
+
+void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information);
+
+typedef struct {
+ float temp;
+ float humidity;
+} front_msb_env_t;
+
+void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env);
+
+typedef struct {
+ float x_force;
+ float y_force;
+ float z_force;
+} front_msb_accel_t;
+
+void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel);
+
+typedef struct {
+ float x_deg;
+ float y_deg;
+ float z_deg;
+} front_msb_gyro_t;
+
+void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro);
+
+typedef struct {
+ uint32_t strain1;
+ uint32_t strain2;
+} front_msb_strain_t;
+
+void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain);
+
+typedef struct {
+ float shock1;
+ uint16_t shock1_raw;
+} front_shockpot_t;
+
+void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot);
+
+typedef struct {
+ float rh;
+} front_ride_height_t;
+
+void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height);
+
+typedef struct {
+ float wheel_temp;
+} front_wheel_temp_t;
+
+void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp);
+
+typedef struct {
+ float x_fdeg;
+ float y_fdeg;
+ float z_fdeg;
+} front_msb_orientation_t;
+
+void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation);
+
+typedef struct {
+ float temp;
+ float humidity;
+} back_msb_env_t;
+
+void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env);
+
+typedef struct {
+ float x_force;
+ float y_force;
+ float z_force;
+} back_msb_accel_t;
+
+void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel);
+
+typedef struct {
+ float x_deg;
+ float y_deg;
+ float z_deg;
+} back_msb_gyro_t;
+
+void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro);
+
+typedef struct {
+ uint32_t strain1;
+ uint32_t strain2;
+} back_msb_strain_t;
+
+void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain);
+
+typedef struct {
+ float shock1;
+ uint16_t shock1_raw;
+} back_shockpot_t;
+
+void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot);
+
+typedef struct {
+ float rh;
+} back_ride_height_t;
+
+void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height);
+
+typedef struct {
+ float wheel_temp;
+} back_wheel_temp_t;
+
+void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp);
+
+typedef struct {
+ float x_fdeg;
+ float y_fdeg;
+ float z_fdeg;
+} back_msb_orientation_t;
+
+void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation);
+
+typedef struct {
+ float accel_x;
+ float accel_y;
+ float accel_z;
+} lightning_board_imu_acceleration_data_t;
+
+void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data);
+
+typedef struct {
+ float gyro_x;
+ float gyro_y;
+ float gyro_z;
+} lightning_board_imu_gyro_data_t;
+
+void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data);
+
+typedef struct {
+ uint8_t interrupt;
+ uint8_t distance;
+ uint32_t energy;
+} lightning_board_lightning_sensor_information_t;
+
+void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information);
+
+typedef struct {
+ float mag_x;
+ float mag_y;
+ float mag_z;
+} lightning_board_magnometer_sensor_information_t;
+
+void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information);
 
 typedef struct {
  uint16_t ADC;
@@ -265,6 +421,7 @@ void receive_car_state(const can_msg_t *message, car_state_t *car_state);
 typedef struct {
  float accel_norm;
  float brake_norm;
+ float brake_psi;
 } pedal_percent_pressed_values_t;
 
 void receive_pedal_percent_pressed_values(const can_msg_t *message, pedal_percent_pressed_values_t *pedal_percent_pressed_values);
@@ -418,178 +575,34 @@ typedef struct {
 void receive_bms_shutdown_status_as_reported_by_vcu(const can_msg_t *message, bms_shutdown_status_as_reported_by_vcu_t *bms_shutdown_status_as_reported_by_vcu);
 
 typedef struct {
- uint8_t button_id;
-} wheel_buttons_t;
+ bool BRAKE_OC;
+ bool BRAKE_SC;
+ bool ACCEL_OC;
+ bool ACCEL_SC;
+ bool ACCEL_DIFF;
+ bool BSPD_PREF;
+  empty;
+} drive_lock_states_t;
 
-void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons);
-
-typedef struct {
- float accel_x;
- float accel_y;
- float accel_z;
-} lightning_board_imu_acceleration_data_t;
-
-void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data);
+void receive_drive_lock_states(const can_msg_t *message, drive_lock_states_t *drive_lock_states);
 
 typedef struct {
- float gyro_x;
- float gyro_y;
- float gyro_z;
-} lightning_board_imu_gyro_data_t;
+ float current_target_ac;
+} ac_current_command_t;
 
-void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data);
+void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command);
 
 typedef struct {
- uint8_t interrupt;
- uint8_t distance;
- uint32_t energy;
-} lightning_board_lightning_sensor_information_t;
+ float brake_ac_current;
+} brake_current_command_t;
 
-void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information);
+void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command);
 
 typedef struct {
- float mag_x;
- float mag_y;
- float mag_z;
-} lightning_board_magnometer_sensor_information_t;
+ uint8_t drive_enable;
+} drive_enable_command_t;
 
-void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information);
-
-typedef struct {
- float temp;
- float humidity;
-} front_msb_env_t;
-
-void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env);
-
-typedef struct {
- float x_force;
- float y_force;
- float z_force;
-} front_msb_accel_t;
-
-void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel);
-
-typedef struct {
- float x_deg;
- float y_deg;
- float z_deg;
-} front_msb_gyro_t;
-
-void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro);
-
-typedef struct {
- uint32_t strain1;
- uint32_t strain2;
-} front_msb_strain_t;
-
-void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain);
-
-typedef struct {
- float shock1;
- uint16_t shock1_raw;
-} front_shockpot_t;
-
-void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot);
-
-typedef struct {
- float rh;
-} front_ride_height_t;
-
-void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height);
-
-typedef struct {
- float wheel_temp;
-} front_wheel_temp_t;
-
-void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp);
-
-typedef struct {
- float x_fdeg;
- float y_fdeg;
- float z_fdeg;
-} front_msb_orientation_t;
-
-void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation);
-
-typedef struct {
- float temp;
- float humidity;
-} back_msb_env_t;
-
-void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env);
-
-typedef struct {
- float x_force;
- float y_force;
- float z_force;
-} back_msb_accel_t;
-
-void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel);
-
-typedef struct {
- float x_deg;
- float y_deg;
- float z_deg;
-} back_msb_gyro_t;
-
-void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro);
-
-typedef struct {
- uint32_t strain1;
- uint32_t strain2;
-} back_msb_strain_t;
-
-void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain);
-
-typedef struct {
- float shock1;
- uint16_t shock1_raw;
-} back_shockpot_t;
-
-void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot);
-
-typedef struct {
- float rh;
-} back_ride_height_t;
-
-void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height);
-
-typedef struct {
- float wheel_temp;
-} back_wheel_temp_t;
-
-void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp);
-
-typedef struct {
- float x_fdeg;
- float y_fdeg;
- float z_fdeg;
-} back_msb_orientation_t;
-
-void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation);
-
-typedef struct {
- uint16_t R_iso_corrected;
- uint8_t R_iso_status;
- uint8_t Iso_measurement_counter;
- bool device_error;
- bool HV_pos_conn_fail;
- bool HV_neg_conn_fail;
- bool Earth_conn_fail;
- bool Iso_alarm;
- bool iso_warning;
- bool iso_outdated;
- bool Unbalance_alarm;
- bool Undervoltage_alarm;
- bool Unsafe_to_start;
- bool Earthlift_Open;
- uint8_t warnings_and_alarms_unused_bits;
- uint8_t Device_Activity;
- uint8_t Not_Applicable;
-} imd_general_information_t;
-
-void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information);
+void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command);
 
 
 void receive_can(const can_msg_t *msg);

--- a/Core/Inc/can_messages_rx.h
+++ b/Core/Inc/can_messages_rx.h
@@ -15,6 +15,24 @@
 #include "bitstream.h"
 
 typedef struct {
+ float current_target_ac;
+} ac_current_command_t;
+
+void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command);
+
+typedef struct {
+ float brake_ac_current;
+} brake_current_command_t;
+
+void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command);
+
+typedef struct {
+ uint8_t drive_enable;
+} drive_enable_command_t;
+
+void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command);
+
+typedef struct {
  uint8_t pwm_duty;
 } shepherd_bms_fan_percent_t;
 
@@ -91,180 +109,6 @@ typedef struct {
 } rtds_command_message_t;
 
 void receive_rtds_command_message(const can_msg_t *message, rtds_command_message_t *rtds_command_message);
-
-typedef struct {
- uint8_t button_id;
-} wheel_buttons_t;
-
-void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons);
-
-typedef struct {
- uint16_t R_iso_corrected;
- uint8_t R_iso_status;
- uint8_t Iso_measurement_counter;
- bool device_error;
- bool HV_pos_conn_fail;
- bool HV_neg_conn_fail;
- bool Earth_conn_fail;
- bool Iso_alarm;
- bool iso_warning;
- bool iso_outdated;
- bool Unbalance_alarm;
- bool Undervoltage_alarm;
- bool Unsafe_to_start;
- bool Earthlift_Open;
- uint8_t warnings_and_alarms_unused_bits;
- uint8_t Device_Activity;
- uint8_t Not_Applicable;
-} imd_general_information_t;
-
-void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information);
-
-typedef struct {
- float temp;
- float humidity;
-} front_msb_env_t;
-
-void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env);
-
-typedef struct {
- float x_force;
- float y_force;
- float z_force;
-} front_msb_accel_t;
-
-void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel);
-
-typedef struct {
- float x_deg;
- float y_deg;
- float z_deg;
-} front_msb_gyro_t;
-
-void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro);
-
-typedef struct {
- uint32_t strain1;
- uint32_t strain2;
-} front_msb_strain_t;
-
-void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain);
-
-typedef struct {
- float shock1;
- uint16_t shock1_raw;
-} front_shockpot_t;
-
-void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot);
-
-typedef struct {
- float rh;
-} front_ride_height_t;
-
-void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height);
-
-typedef struct {
- float wheel_temp;
-} front_wheel_temp_t;
-
-void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp);
-
-typedef struct {
- float x_fdeg;
- float y_fdeg;
- float z_fdeg;
-} front_msb_orientation_t;
-
-void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation);
-
-typedef struct {
- float temp;
- float humidity;
-} back_msb_env_t;
-
-void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env);
-
-typedef struct {
- float x_force;
- float y_force;
- float z_force;
-} back_msb_accel_t;
-
-void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel);
-
-typedef struct {
- float x_deg;
- float y_deg;
- float z_deg;
-} back_msb_gyro_t;
-
-void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro);
-
-typedef struct {
- uint32_t strain1;
- uint32_t strain2;
-} back_msb_strain_t;
-
-void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain);
-
-typedef struct {
- float shock1;
- uint16_t shock1_raw;
-} back_shockpot_t;
-
-void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot);
-
-typedef struct {
- float rh;
-} back_ride_height_t;
-
-void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height);
-
-typedef struct {
- float wheel_temp;
-} back_wheel_temp_t;
-
-void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp);
-
-typedef struct {
- float x_fdeg;
- float y_fdeg;
- float z_fdeg;
-} back_msb_orientation_t;
-
-void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation);
-
-typedef struct {
- float accel_x;
- float accel_y;
- float accel_z;
-} lightning_board_imu_acceleration_data_t;
-
-void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data);
-
-typedef struct {
- float gyro_x;
- float gyro_y;
- float gyro_z;
-} lightning_board_imu_gyro_data_t;
-
-void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data);
-
-typedef struct {
- uint8_t interrupt;
- uint8_t distance;
- uint32_t energy;
-} lightning_board_lightning_sensor_information_t;
-
-void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information);
-
-typedef struct {
- float mag_x;
- float mag_y;
- float mag_z;
-} lightning_board_magnometer_sensor_information_t;
-
-void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information);
 
 typedef struct {
  uint16_t ADC;
@@ -398,7 +242,6 @@ typedef struct {
  bool ckpt_gpio;
  bool inertia_sw_gpio;
  bool tsms_gpio;
- uint8_t UNUSED;
 } shutdown_pins_t;
 
 void receive_shutdown_pins(const can_msg_t *message, shutdown_pins_t *shutdown_pins);
@@ -421,7 +264,8 @@ void receive_car_state(const can_msg_t *message, car_state_t *car_state);
 typedef struct {
  float accel_norm;
  float brake_norm;
- float brake_psi;
+ float brake_psi_brake1;
+ float brake_psi_brake2;
 } pedal_percent_pressed_values_t;
 
 void receive_pedal_percent_pressed_values(const can_msg_t *message, pedal_percent_pressed_values_t *pedal_percent_pressed_values);
@@ -581,28 +425,186 @@ typedef struct {
  bool ACCEL_SC;
  bool ACCEL_DIFF;
  bool BSPD_PREF;
-  empty;
+ bool BMS_NOT_PRECHARGED_YET;
 } drive_lock_states_t;
 
 void receive_drive_lock_states(const can_msg_t *message, drive_lock_states_t *drive_lock_states);
 
 typedef struct {
- float current_target_ac;
-} ac_current_command_t;
+ uint8_t button_id;
+} wheel_buttons_t;
 
-void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command);
-
-typedef struct {
- float brake_ac_current;
-} brake_current_command_t;
-
-void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command);
+void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons);
 
 typedef struct {
- uint8_t drive_enable;
-} drive_enable_command_t;
+ float accel_x;
+ float accel_y;
+ float accel_z;
+} lightning_board_imu_acceleration_data_t;
 
-void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command);
+void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data);
+
+typedef struct {
+ float gyro_x;
+ float gyro_y;
+ float gyro_z;
+} lightning_board_imu_gyro_data_t;
+
+void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data);
+
+typedef struct {
+ uint8_t interrupt;
+ uint8_t distance;
+ uint32_t energy;
+} lightning_board_lightning_sensor_information_t;
+
+void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information);
+
+typedef struct {
+ float mag_x;
+ float mag_y;
+ float mag_z;
+} lightning_board_magnometer_sensor_information_t;
+
+void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information);
+
+typedef struct {
+ uint32_t count;
+} lightning_pulse_message_t;
+
+void receive_lightning_pulse_message(const can_msg_t *message, lightning_pulse_message_t *lightning_pulse_message);
+
+typedef struct {
+ float temp;
+ float humidity;
+} front_msb_env_t;
+
+void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env);
+
+typedef struct {
+ float x_force;
+ float y_force;
+ float z_force;
+} front_msb_accel_t;
+
+void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel);
+
+typedef struct {
+ float x_deg;
+ float y_deg;
+ float z_deg;
+} front_msb_gyro_t;
+
+void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro);
+
+typedef struct {
+ uint32_t strain1;
+ uint32_t strain2;
+} front_msb_strain_t;
+
+void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain);
+
+typedef struct {
+ float shock1;
+ uint16_t shock1_raw;
+} front_shockpot_t;
+
+void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot);
+
+typedef struct {
+ float rh;
+} front_ride_height_t;
+
+void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height);
+
+typedef struct {
+ float wheel_temp;
+} front_wheel_temp_t;
+
+void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp);
+
+typedef struct {
+ float x_fdeg;
+ float y_fdeg;
+ float z_fdeg;
+} front_msb_orientation_t;
+
+void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation);
+
+typedef struct {
+ float temp;
+ float humidity;
+} back_msb_env_t;
+
+void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env);
+
+typedef struct {
+ float x_force;
+ float y_force;
+ float z_force;
+} back_msb_accel_t;
+
+void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel);
+
+typedef struct {
+ float x_deg;
+ float y_deg;
+ float z_deg;
+} back_msb_gyro_t;
+
+void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro);
+
+typedef struct {
+ uint32_t strain1;
+ uint32_t strain2;
+} back_msb_strain_t;
+
+void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain);
+
+typedef struct {
+ float shock1;
+ uint16_t shock1_raw;
+} back_shockpot_t;
+
+void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot);
+
+typedef struct {
+ float rh;
+} back_ride_height_t;
+
+void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height);
+
+typedef struct {
+ float wheel_temp;
+} back_wheel_temp_t;
+
+void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp);
+
+typedef struct {
+ float x_fdeg;
+ float y_fdeg;
+ float z_fdeg;
+} back_msb_orientation_t;
+
+void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation);
+
+typedef struct {
+ uint16_t R_iso_corrected;
+ uint8_t R_iso_status;
+ uint8_t Iso_measurement_counter;
+ bool device_error;
+ bool HV_pos_conn_fail;
+ bool HV_neg_conn_fail;
+ bool Earth_conn_fail;
+ bool Iso_alarm;
+ bool iso_warning;
+ bool iso_outdated;
+ bool Unbalance_alarm;
+ bool Undervoltage_alarm;
+ bool Unsafe_to_start;
+} imd_general_information_t;
+
+void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information);
 
 
 void receive_can(const can_msg_t *msg);

--- a/Core/Inc/can_messages_tx.h
+++ b/Core/Inc/can_messages_tx.h
@@ -10,34 +10,6 @@
 
 /**
 * Contents of this message:
-* BMS/Commands/Max_AC_Current_Target - This value determines the maximum allowable drive current on the AC side
-*/
-uint8_t send_max_ac_current_command
-(float max_current_ac_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_AC_Brake_Current_Target - This value sets the maximum allowable brake current on the AC side
-*/
-uint8_t send_max_ac_brake_current_command
-(float max_ac_brake_current_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_DC_Current_Target - This value determines the maximum allowable drive current on the DC side
-*/
-uint8_t send_max_dc_current_command
-(float max_dc_current_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_DC_Brake_Current_Target - This value determines the maximum allowable brake current on the DC side
-*/
-uint8_t send_max_dc_brake_current_command
-(float max_dc_brake_current_target);
-
-/**
-* Contents of this message:
 * BMS/Status/State - The system state
 * BMS/Status/Temp_Average - Average of all thermistor readings
 */
@@ -374,9 +346,13 @@ uint8_t send_pack_soc_status
 /**
 * Contents of this message:
 * BMS/shutdown/state - Current shutdown state
+* BMS/shutdown/ts_minus_sense - TS minus sense gpio state
+* BMS/shutdown/ts_plus_sense - TS plus sense gpio state
+* BMS/shutdown/acc_sense - Accelerometer sense gpio state
+* BMS/shutdown/tsip_sense - TSIP sense gpio state
 */
 uint8_t send_shutdown_as_read_by_bms
-(bool shutdown);
+(bool shutdown,bool ts_minus_sense,bool ts_plus_sense,bool acc_sense,bool tsip_sense);
 
 /**
 * Contents of this message:
@@ -404,4 +380,32 @@ uint8_t send_bms_critically_faulted
 */
 uint8_t send_bms_charge_message_send
 (float charge_volts,float charge_current,uint8_t enable_charging);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_AC_Current_Target - This value determines the maximum allowable drive current on the AC side
+*/
+uint8_t send_max_ac_current_command
+(float max_current_ac_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_AC_Brake_Current_Target - This value sets the maximum allowable brake current on the AC side
+*/
+uint8_t send_max_ac_brake_current_command
+(float max_ac_brake_current_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_DC_Current_Target - This value determines the maximum allowable drive current on the DC side
+*/
+uint8_t send_max_dc_current_command
+(float max_dc_current_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_DC_Brake_Current_Target - This value determines the maximum allowable brake current on the DC side
+*/
+uint8_t send_max_dc_brake_current_command
+(float max_dc_brake_current_target);
 #endif

--- a/Core/Inc/can_messages_tx.h
+++ b/Core/Inc/can_messages_tx.h
@@ -10,6 +10,34 @@
 
 /**
 * Contents of this message:
+* BMS/Commands/Max_AC_Current_Target - This value determines the maximum allowable drive current on the AC side
+*/
+uint8_t send_max_ac_current_command
+(float max_current_ac_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_AC_Brake_Current_Target - This value sets the maximum allowable brake current on the AC side
+*/
+uint8_t send_max_ac_brake_current_command
+(float max_ac_brake_current_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_DC_Current_Target - This value determines the maximum allowable drive current on the DC side
+*/
+uint8_t send_max_dc_current_command
+(float max_dc_current_target);
+
+/**
+* Contents of this message:
+* BMS/Commands/Max_DC_Brake_Current_Target - This value determines the maximum allowable brake current on the DC side
+*/
+uint8_t send_max_dc_brake_current_command
+(float max_dc_brake_current_target);
+
+/**
+* Contents of this message:
 * BMS/Status/State - The system state
 * BMS/Status/Temp_Average - Average of all thermistor readings
 */
@@ -345,14 +373,14 @@ uint8_t send_pack_soc_status
 
 /**
 * Contents of this message:
-* BMS/shutdown/state - Current shutdown state
-* BMS/shutdown/ts_minus_sense - TS minus sense gpio state
-* BMS/shutdown/ts_plus_sense - TS plus sense gpio state
-* BMS/shutdown/acc_sense - Accelerometer sense gpio state
-* BMS/shutdown/tsip_sense - TSIP sense gpio state
+* BMS/Shutdown/State - Current shutdown state
+* BMS/Shutdown/TS_Minus_Sense - 
+* BMS/Shutdown/TS_Plus_Sense - 
+* BMS/Shutdown/Acc_Sense - 
+* BMS/Shutdown/TSIP_Sense - 
 */
 uint8_t send_shutdown_as_read_by_bms
-(bool shutdown,bool ts_minus_sense,bool ts_plus_sense,bool acc_sense,bool tsip_sense);
+(bool shutdown_state,bool shutdown_ts_minus_sense,bool shutdown_ts_plus_sense,bool shutdown_acc_sense,bool shutdown_tsip_sense);
 
 /**
 * Contents of this message:
@@ -380,32 +408,4 @@ uint8_t send_bms_critically_faulted
 */
 uint8_t send_bms_charge_message_send
 (float charge_volts,float charge_current,uint8_t enable_charging);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_AC_Current_Target - This value determines the maximum allowable drive current on the AC side
-*/
-uint8_t send_max_ac_current_command
-(float max_current_ac_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_AC_Brake_Current_Target - This value sets the maximum allowable brake current on the AC side
-*/
-uint8_t send_max_ac_brake_current_command
-(float max_ac_brake_current_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_DC_Current_Target - This value determines the maximum allowable drive current on the DC side
-*/
-uint8_t send_max_dc_current_command
-(float max_dc_current_target);
-
-/**
-* Contents of this message:
-* BMS/Commands/Max_DC_Brake_Current_Target - This value determines the maximum allowable brake current on the DC side
-*/
-uint8_t send_max_dc_brake_current_command
-(float max_dc_brake_current_target);
 #endif

--- a/Core/Inc/compute.h
+++ b/Core/Inc/compute.h
@@ -56,6 +56,10 @@ void compute_set_fault(bool fault_state);
 /**
  * @brief Checks if the shutdown circuit is open.
  */
+bool read_shutdown_ts_minus_sense(void);
+bool read_shutdown_ts_plus_sense(void);
+bool read_shutdown_acc_sense(void);
+bool read_shutdown_tsip_sense(void);
 void read_shutdown(peripherals_t *peripherals);
 
 /**

--- a/Core/Src/can_messages_rx.c
+++ b/Core/Src/can_messages_rx.c
@@ -1,5 +1,39 @@
 #include "can_messages_rx.h"
 
+void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t current_target_ac_mask = (1ULL << 16) - 1ULL;
+    uint64_t current_target_ac_bits = (data >> 0) & current_target_ac_mask;
+    int64_t current_target_ac_raw = (current_target_ac_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(current_target_ac_bits | ~current_target_ac_mask)
+        : (int64_t)current_target_ac_bits;
+    ac_current_command->current_target_ac = (float)(current_target_ac_raw / 10);
+}
+
+void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t brake_ac_current_mask = (1ULL << 16) - 1ULL;
+    uint64_t brake_ac_current_bits = (data >> 48) & brake_ac_current_mask;
+    int64_t brake_ac_current_raw = (brake_ac_current_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(brake_ac_current_bits | ~brake_ac_current_mask)
+        : (int64_t)brake_ac_current_bits;
+    brake_current_command->brake_ac_current = (float)(brake_ac_current_raw / 10);
+}
+
+void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command) {
+    
+    uint8_t data = message->data[0];
+    uint64_t drive_enable_mask = (1ULL << 8) - 1ULL;
+    uint64_t drive_enable_raw = (data >> 0) & drive_enable_mask;
+    drive_enable_command->drive_enable = (uint8_t)drive_enable_raw;
+}
+
 void receive_shepherd_bms_fan_percent(const can_msg_t *message, shepherd_bms_fan_percent_t *shepherd_bms_fan_percent) {
     
     uint8_t data = message->data[0];
@@ -102,491 +136,6 @@ void receive_rtds_command_message(const can_msg_t *message, rtds_command_message
     uint64_t command_mask = (1ULL << 8) - 1ULL;
     uint64_t command_raw = (data >> 0) & command_mask;
     rtds_command_message->command = (uint8_t)command_raw;
-}
-
-void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons) {
-    
-    uint8_t data = message->data[0];
-    uint64_t button_id_mask = (1ULL << 8) - 1ULL;
-    uint64_t button_id_raw = (data >> 0) & button_id_mask;
-    wheel_buttons->button_id = (uint8_t)button_id_raw;
-}
-
-void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information) {
-    
-    struct __attribute__((__packed__)) {
-        uint16_t R_iso_corrected;
-        uint8_t R_iso_status;
-        uint8_t Iso_measurement_counter;
-        uint8_t device_error;
-        uint8_t HV_pos_conn_fail;
-        uint8_t HV_neg_conn_fail;
-        uint8_t Earth_conn_fail;
-        uint8_t Iso_alarm;
-        uint8_t iso_warning;
-        uint8_t iso_outdated;
-        uint8_t Unbalance_alarm;
-        uint8_t Undervoltage_alarm;
-        uint8_t Unsafe_to_start;
-        uint8_t Earthlift_Open;
-        uint8_t warnings_and_alarms_unused_bits;
-        uint8_t Device_Activity;
-        uint8_t Not_Applicable;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    imd_general_information->R_iso_corrected = (uint16_t)bitstream_data.R_iso_corrected;
-    
-    
-    
-    imd_general_information->R_iso_status = (uint8_t)bitstream_data.R_iso_status;
-    
-    
-    
-    imd_general_information->Iso_measurement_counter = (uint8_t)bitstream_data.Iso_measurement_counter;
-    
-    
-    
-    imd_general_information->device_error = (bool)bitstream_data.device_error;
-    
-    
-    
-    imd_general_information->HV_pos_conn_fail = (bool)bitstream_data.HV_pos_conn_fail;
-    
-    
-    
-    imd_general_information->HV_neg_conn_fail = (bool)bitstream_data.HV_neg_conn_fail;
-    
-    
-    
-    imd_general_information->Earth_conn_fail = (bool)bitstream_data.Earth_conn_fail;
-    
-    
-    
-    imd_general_information->Iso_alarm = (bool)bitstream_data.Iso_alarm;
-    
-    
-    
-    imd_general_information->iso_warning = (bool)bitstream_data.iso_warning;
-    
-    
-    
-    imd_general_information->iso_outdated = (bool)bitstream_data.iso_outdated;
-    
-    
-    
-    imd_general_information->Unbalance_alarm = (bool)bitstream_data.Unbalance_alarm;
-    
-    
-    
-    imd_general_information->Undervoltage_alarm = (bool)bitstream_data.Undervoltage_alarm;
-    
-    
-    
-    imd_general_information->Unsafe_to_start = (bool)bitstream_data.Unsafe_to_start;
-    
-    
-    
-    imd_general_information->Earthlift_Open = (bool)bitstream_data.Earthlift_Open;
-    
-    
-    
-    imd_general_information->warnings_and_alarms_unused_bits = (uint8_t)bitstream_data.warnings_and_alarms_unused_bits;
-    
-    
-    
-    imd_general_information->Device_Activity = (uint8_t)bitstream_data.Device_Activity;
-    
-    
-    
-    imd_general_information->Not_Applicable = (uint8_t)bitstream_data.Not_Applicable;
-    
-    
-}
-
-void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env) {
-    
-    uint32_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 4);
-    uint32_t data = __builtin_bswap32(data_bigendian);
-    uint64_t temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t temp_raw = (data >> 16) & temp_mask;
-    front_msb_env->temp = (float)(temp_raw / 10);
-    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
-    uint64_t humidity_raw = (data >> 0) & humidity_mask;
-    front_msb_env->humidity = (float)(humidity_raw / 10);
-}
-
-void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_force_bits = (data >> 48) & x_force_mask;
-    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_force_bits | ~x_force_mask)
-        : (int64_t)x_force_bits;
-    front_msb_accel->x_force = (float)x_force_raw;
-    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_force_bits = (data >> 32) & y_force_mask;
-    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_force_bits | ~y_force_mask)
-        : (int64_t)y_force_bits;
-    front_msb_accel->y_force = (float)y_force_raw;
-    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_force_bits = (data >> 16) & z_force_mask;
-    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_force_bits | ~z_force_mask)
-        : (int64_t)z_force_bits;
-    front_msb_accel->z_force = (float)z_force_raw;
-}
-
-void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
-    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_deg_bits | ~x_deg_mask)
-        : (int64_t)x_deg_bits;
-    front_msb_gyro->x_deg = (float)x_deg_raw;
-    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
-    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_deg_bits | ~y_deg_mask)
-        : (int64_t)y_deg_bits;
-    front_msb_gyro->y_deg = (float)y_deg_raw;
-    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
-    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_deg_bits | ~z_deg_mask)
-        : (int64_t)z_deg_bits;
-    front_msb_gyro->z_deg = (float)z_deg_raw;
-}
-
-void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain1_raw = (data >> 32) & strain1_mask;
-    front_msb_strain->strain1 = (uint32_t)strain1_raw;
-    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain2_raw = (data >> 0) & strain2_mask;
-    front_msb_strain->strain2 = (uint32_t)strain2_raw;
-}
-
-void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot) {
-    
-    struct __attribute__((__packed__)) {
-        uint32_t shock1;
-        uint16_t shock1_raw;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    front_shockpot->shock1 = (float)bitstream_data.shock1;
-    
-    
-    
-    front_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
-    
-    
-}
-
-void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t rh_mask = (1ULL << 16) - 1ULL;
-    uint64_t rh_bits = (data >> 0) & rh_mask;
-    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(rh_bits | ~rh_mask)
-        : (int64_t)rh_bits;
-    front_ride_height->rh = (float)rh_raw;
-}
-
-void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
-    front_wheel_temp->wheel_temp = (float)wheel_temp_raw;
-}
-
-void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
-    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
-        : (int64_t)x_fdeg_bits;
-    front_msb_orientation->x_fdeg = (float)x_fdeg_raw;
-    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
-    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
-        : (int64_t)y_fdeg_bits;
-    front_msb_orientation->y_fdeg = (float)y_fdeg_raw;
-    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
-    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
-        : (int64_t)z_fdeg_bits;
-    front_msb_orientation->z_fdeg = (float)z_fdeg_raw;
-}
-
-void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env) {
-    
-    uint32_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 4);
-    uint32_t data = __builtin_bswap32(data_bigendian);
-    uint64_t temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t temp_raw = (data >> 16) & temp_mask;
-    back_msb_env->temp = (float)(temp_raw / 10);
-    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
-    uint64_t humidity_raw = (data >> 0) & humidity_mask;
-    back_msb_env->humidity = (float)(humidity_raw / 10);
-}
-
-void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_force_bits = (data >> 48) & x_force_mask;
-    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_force_bits | ~x_force_mask)
-        : (int64_t)x_force_bits;
-    back_msb_accel->x_force = (float)x_force_raw;
-    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_force_bits = (data >> 32) & y_force_mask;
-    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_force_bits | ~y_force_mask)
-        : (int64_t)y_force_bits;
-    back_msb_accel->y_force = (float)y_force_raw;
-    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_force_bits = (data >> 16) & z_force_mask;
-    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_force_bits | ~z_force_mask)
-        : (int64_t)z_force_bits;
-    back_msb_accel->z_force = (float)z_force_raw;
-}
-
-void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
-    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_deg_bits | ~x_deg_mask)
-        : (int64_t)x_deg_bits;
-    back_msb_gyro->x_deg = (float)x_deg_raw;
-    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
-    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_deg_bits | ~y_deg_mask)
-        : (int64_t)y_deg_bits;
-    back_msb_gyro->y_deg = (float)y_deg_raw;
-    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
-    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_deg_bits | ~z_deg_mask)
-        : (int64_t)z_deg_bits;
-    back_msb_gyro->z_deg = (float)z_deg_raw;
-}
-
-void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain1_raw = (data >> 32) & strain1_mask;
-    back_msb_strain->strain1 = (uint32_t)strain1_raw;
-    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain2_raw = (data >> 0) & strain2_mask;
-    back_msb_strain->strain2 = (uint32_t)strain2_raw;
-}
-
-void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot) {
-    
-    struct __attribute__((__packed__)) {
-        uint32_t shock1;
-        uint16_t shock1_raw;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    back_shockpot->shock1 = (float)bitstream_data.shock1;
-    
-    
-    
-    back_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
-    
-    
-}
-
-void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t rh_mask = (1ULL << 16) - 1ULL;
-    uint64_t rh_bits = (data >> 0) & rh_mask;
-    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(rh_bits | ~rh_mask)
-        : (int64_t)rh_bits;
-    back_ride_height->rh = (float)rh_raw;
-}
-
-void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
-    back_wheel_temp->wheel_temp = (float)wheel_temp_raw;
-}
-
-void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
-    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
-        : (int64_t)x_fdeg_bits;
-    back_msb_orientation->x_fdeg = (float)x_fdeg_raw;
-    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
-    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
-        : (int64_t)y_fdeg_bits;
-    back_msb_orientation->y_fdeg = (float)y_fdeg_raw;
-    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
-    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
-        : (int64_t)z_fdeg_bits;
-    back_msb_orientation->z_fdeg = (float)z_fdeg_raw;
-}
-
-void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t accel_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_x_bits = (data >> 48) & accel_x_mask;
-    int64_t accel_x_raw = (accel_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_x_bits | ~accel_x_mask)
-        : (int64_t)accel_x_bits;
-    lightning_board_imu_acceleration_data->accel_x = (float)(accel_x_raw / 1000);
-    uint64_t accel_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_y_bits = (data >> 32) & accel_y_mask;
-    int64_t accel_y_raw = (accel_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_y_bits | ~accel_y_mask)
-        : (int64_t)accel_y_bits;
-    lightning_board_imu_acceleration_data->accel_y = (float)(accel_y_raw / 1000);
-    uint64_t accel_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_z_bits = (data >> 16) & accel_z_mask;
-    int64_t accel_z_raw = (accel_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_z_bits | ~accel_z_mask)
-        : (int64_t)accel_z_bits;
-    lightning_board_imu_acceleration_data->accel_z = (float)(accel_z_raw / 1000);
-}
-
-void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t gyro_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_x_bits = (data >> 48) & gyro_x_mask;
-    int64_t gyro_x_raw = (gyro_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_x_bits | ~gyro_x_mask)
-        : (int64_t)gyro_x_bits;
-    lightning_board_imu_gyro_data->gyro_x = (float)(gyro_x_raw / 1000);
-    uint64_t gyro_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_y_bits = (data >> 32) & gyro_y_mask;
-    int64_t gyro_y_raw = (gyro_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_y_bits | ~gyro_y_mask)
-        : (int64_t)gyro_y_bits;
-    lightning_board_imu_gyro_data->gyro_y = (float)(gyro_y_raw / 1000);
-    uint64_t gyro_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_z_bits = (data >> 16) & gyro_z_mask;
-    int64_t gyro_z_raw = (gyro_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_z_bits | ~gyro_z_mask)
-        : (int64_t)gyro_z_bits;
-    lightning_board_imu_gyro_data->gyro_z = (float)(gyro_z_raw / 1000);
-}
-
-void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t interrupt_mask = (1ULL << 8) - 1ULL;
-    uint64_t interrupt_raw = (data >> 56) & interrupt_mask;
-    lightning_board_lightning_sensor_information->interrupt = (uint8_t)interrupt_raw;
-    uint64_t distance_mask = (1ULL << 8) - 1ULL;
-    uint64_t distance_raw = (data >> 48) & distance_mask;
-    lightning_board_lightning_sensor_information->distance = (uint8_t)distance_raw;
-    uint64_t energy_mask = (1ULL << 32) - 1ULL;
-    uint64_t energy_raw = (data >> 16) & energy_mask;
-    lightning_board_lightning_sensor_information->energy = (uint32_t)energy_raw;
-}
-
-void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t mag_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_x_bits = (data >> 48) & mag_x_mask;
-    int64_t mag_x_raw = (mag_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_x_bits | ~mag_x_mask)
-        : (int64_t)mag_x_bits;
-    lightning_board_magnometer_sensor_information->mag_x = (float)(mag_x_raw / 1000);
-    uint64_t mag_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_y_bits = (data >> 32) & mag_y_mask;
-    int64_t mag_y_raw = (mag_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_y_bits | ~mag_y_mask)
-        : (int64_t)mag_y_bits;
-    lightning_board_magnometer_sensor_information->mag_y = (float)(mag_y_raw / 1000);
-    uint64_t mag_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_z_bits = (data >> 16) & mag_z_mask;
-    int64_t mag_z_raw = (mag_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_z_bits | ~mag_z_mask)
-        : (int64_t)mag_z_bits;
-    lightning_board_magnometer_sensor_information->mag_z = (float)(mag_z_raw / 1000);
 }
 
 void receive_dashboard_efuse(const can_msg_t *message, dashboard_efuse_t *dashboard_efuse) {
@@ -899,9 +448,6 @@ void receive_shutdown_pins(const can_msg_t *message, shutdown_pins_t *shutdown_p
     uint64_t tsms_gpio_mask = (1ULL << 1) - 1ULL;
     uint64_t tsms_gpio_raw = (data >> 6) & tsms_gpio_mask;
     shutdown_pins->tsms_gpio = (bool)tsms_gpio_raw;
-    uint64_t UNUSED_mask = (1ULL << 6) - 1ULL;
-    uint64_t UNUSED_raw = (data >> 0) & UNUSED_mask;
-    shutdown_pins->UNUSED = (uint8_t)UNUSED_raw;
 }
 
 void receive_car_state(const can_msg_t *message, car_state_t *car_state) {
@@ -955,12 +501,18 @@ void receive_pedal_percent_pressed_values(const can_msg_t *message, pedal_percen
     uint64_t brake_norm_mask = (1ULL << 16) - 1ULL;
     uint64_t brake_norm_raw = (data >> 32) & brake_norm_mask;
     pedal_percent_pressed_values->brake_norm = (float)(brake_norm_raw / 100);
-    uint64_t brake_psi_mask = (1ULL << 16) - 1ULL;
-    uint64_t brake_psi_bits = (data >> 16) & brake_psi_mask;
-    int64_t brake_psi_raw = (brake_psi_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(brake_psi_bits | ~brake_psi_mask)
-        : (int64_t)brake_psi_bits;
-    pedal_percent_pressed_values->brake_psi = (float)(brake_psi_raw / 10);
+    uint64_t brake_psi_brake1_mask = (1ULL << 16) - 1ULL;
+    uint64_t brake_psi_brake1_bits = (data >> 16) & brake_psi_brake1_mask;
+    int64_t brake_psi_brake1_raw = (brake_psi_brake1_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(brake_psi_brake1_bits | ~brake_psi_brake1_mask)
+        : (int64_t)brake_psi_brake1_bits;
+    pedal_percent_pressed_values->brake_psi_brake1 = (float)(brake_psi_brake1_raw / 10);
+    uint64_t brake_psi_brake2_mask = (1ULL << 16) - 1ULL;
+    uint64_t brake_psi_brake2_bits = (data >> 0) & brake_psi_brake2_mask;
+    int64_t brake_psi_brake2_raw = (brake_psi_brake2_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(brake_psi_brake2_bits | ~brake_psi_brake2_mask)
+        : (int64_t)brake_psi_brake2_bits;
+    pedal_percent_pressed_values->brake_psi_brake2 = (float)(brake_psi_brake2_raw / 10);
 }
 
 void receive_pedal_sensor_voltages(const can_msg_t *message, pedal_sensor_voltages_t *pedal_sensor_voltages) {
@@ -1041,19 +593,19 @@ void receive_imu_gyro(const can_msg_t *message, imu_gyro_t *imu_gyro) {
     int64_t imu_gyro_x_raw = (imu_gyro_x_bits & (1ULL << (16 - 1)))
         ? (int64_t)(imu_gyro_x_bits | ~imu_gyro_x_mask)
         : (int64_t)imu_gyro_x_bits;
-    imu_gyro->imu_gyro_x = (float)(imu_gyro_x_raw / 100);
+    imu_gyro->imu_gyro_x = (float)(imu_gyro_x_raw / 4);
     uint64_t imu_gyro_y_mask = (1ULL << 16) - 1ULL;
     uint64_t imu_gyro_y_bits = (data >> 32) & imu_gyro_y_mask;
     int64_t imu_gyro_y_raw = (imu_gyro_y_bits & (1ULL << (16 - 1)))
         ? (int64_t)(imu_gyro_y_bits | ~imu_gyro_y_mask)
         : (int64_t)imu_gyro_y_bits;
-    imu_gyro->imu_gyro_y = (float)(imu_gyro_y_raw / 100);
+    imu_gyro->imu_gyro_y = (float)(imu_gyro_y_raw / 4);
     uint64_t imu_gyro_z_mask = (1ULL << 16) - 1ULL;
     uint64_t imu_gyro_z_bits = (data >> 16) & imu_gyro_z_mask;
     int64_t imu_gyro_z_raw = (imu_gyro_z_bits & (1ULL << (16 - 1)))
         ? (int64_t)(imu_gyro_z_bits | ~imu_gyro_z_mask)
         : (int64_t)imu_gyro_z_bits;
-    imu_gyro->imu_gyro_z = (float)(imu_gyro_z_raw / 100);
+    imu_gyro->imu_gyro_z = (float)(imu_gyro_z_raw / 4);
 }
 
 void receive_faults(const can_msg_t *message, faults_t *faults) {
@@ -1315,42 +867,525 @@ void receive_drive_lock_states(const can_msg_t *message, drive_lock_states_t *dr
     uint64_t BSPD_PREF_mask = (1ULL << 1) - 1ULL;
     uint64_t BSPD_PREF_raw = (data >> 2) & BSPD_PREF_mask;
     drive_lock_states->BSPD_PREF = (bool)BSPD_PREF_raw;
-    uint64_t empty_mask = (1ULL << 2) - 1ULL;
-    uint64_t empty_raw = (data >> 0) & empty_mask;
-    drive_lock_states->empty = ()empty_raw;
+    uint64_t BMS_NOT_PRECHARGED_YET_mask = (1ULL << 1) - 1ULL;
+    uint64_t BMS_NOT_PRECHARGED_YET_raw = (data >> 1) & BMS_NOT_PRECHARGED_YET_mask;
+    drive_lock_states->BMS_NOT_PRECHARGED_YET = (bool)BMS_NOT_PRECHARGED_YET_raw;
 }
 
-void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command) {
+void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons) {
     
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t current_target_ac_mask = (1ULL << 16) - 1ULL;
-    uint64_t current_target_ac_bits = (data >> 0) & current_target_ac_mask;
-    int64_t current_target_ac_raw = (current_target_ac_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(current_target_ac_bits | ~current_target_ac_mask)
-        : (int64_t)current_target_ac_bits;
-    ac_current_command->current_target_ac = (float)(current_target_ac_raw / 10);
+    uint8_t data = message->data[0];
+    uint64_t button_id_mask = (1ULL << 8) - 1ULL;
+    uint64_t button_id_raw = (data >> 0) & button_id_mask;
+    wheel_buttons->button_id = (uint8_t)button_id_raw;
 }
 
-void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command) {
+void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data) {
     
     uint64_t data_bigendian;
     memcpy(&data_bigendian, message->data, 8);
     uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t brake_ac_current_mask = (1ULL << 16) - 1ULL;
-    uint64_t brake_ac_current_bits = (data >> 48) & brake_ac_current_mask;
-    int64_t brake_ac_current_raw = (brake_ac_current_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(brake_ac_current_bits | ~brake_ac_current_mask)
-        : (int64_t)brake_ac_current_bits;
-    brake_current_command->brake_ac_current = (float)(brake_ac_current_raw / 10);
+    uint64_t accel_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_x_bits = (data >> 48) & accel_x_mask;
+    int64_t accel_x_raw = (accel_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_x_bits | ~accel_x_mask)
+        : (int64_t)accel_x_bits;
+    lightning_board_imu_acceleration_data->accel_x = (float)(accel_x_raw / 1000);
+    uint64_t accel_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_y_bits = (data >> 32) & accel_y_mask;
+    int64_t accel_y_raw = (accel_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_y_bits | ~accel_y_mask)
+        : (int64_t)accel_y_bits;
+    lightning_board_imu_acceleration_data->accel_y = (float)(accel_y_raw / 1000);
+    uint64_t accel_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_z_bits = (data >> 16) & accel_z_mask;
+    int64_t accel_z_raw = (accel_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_z_bits | ~accel_z_mask)
+        : (int64_t)accel_z_bits;
+    lightning_board_imu_acceleration_data->accel_z = (float)(accel_z_raw / 1000);
 }
 
-void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command) {
+void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data) {
     
-    uint8_t data = message->data[0];
-    uint64_t drive_enable_mask = (1ULL << 8) - 1ULL;
-    uint64_t drive_enable_raw = (data >> 0) & drive_enable_mask;
-    drive_enable_command->drive_enable = (uint8_t)drive_enable_raw;
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t gyro_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_x_bits = (data >> 48) & gyro_x_mask;
+    int64_t gyro_x_raw = (gyro_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_x_bits | ~gyro_x_mask)
+        : (int64_t)gyro_x_bits;
+    lightning_board_imu_gyro_data->gyro_x = (float)(gyro_x_raw / 1000);
+    uint64_t gyro_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_y_bits = (data >> 32) & gyro_y_mask;
+    int64_t gyro_y_raw = (gyro_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_y_bits | ~gyro_y_mask)
+        : (int64_t)gyro_y_bits;
+    lightning_board_imu_gyro_data->gyro_y = (float)(gyro_y_raw / 1000);
+    uint64_t gyro_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_z_bits = (data >> 16) & gyro_z_mask;
+    int64_t gyro_z_raw = (gyro_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_z_bits | ~gyro_z_mask)
+        : (int64_t)gyro_z_bits;
+    lightning_board_imu_gyro_data->gyro_z = (float)(gyro_z_raw / 1000);
+}
+
+void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t interrupt_mask = (1ULL << 8) - 1ULL;
+    uint64_t interrupt_raw = (data >> 56) & interrupt_mask;
+    lightning_board_lightning_sensor_information->interrupt = (uint8_t)interrupt_raw;
+    uint64_t distance_mask = (1ULL << 8) - 1ULL;
+    uint64_t distance_raw = (data >> 48) & distance_mask;
+    lightning_board_lightning_sensor_information->distance = (uint8_t)distance_raw;
+    uint64_t energy_mask = (1ULL << 32) - 1ULL;
+    uint64_t energy_raw = (data >> 16) & energy_mask;
+    lightning_board_lightning_sensor_information->energy = (uint32_t)energy_raw;
+}
+
+void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t mag_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_x_bits = (data >> 48) & mag_x_mask;
+    int64_t mag_x_raw = (mag_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_x_bits | ~mag_x_mask)
+        : (int64_t)mag_x_bits;
+    lightning_board_magnometer_sensor_information->mag_x = (float)(mag_x_raw / 1000);
+    uint64_t mag_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_y_bits = (data >> 32) & mag_y_mask;
+    int64_t mag_y_raw = (mag_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_y_bits | ~mag_y_mask)
+        : (int64_t)mag_y_bits;
+    lightning_board_magnometer_sensor_information->mag_y = (float)(mag_y_raw / 1000);
+    uint64_t mag_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_z_bits = (data >> 16) & mag_z_mask;
+    int64_t mag_z_raw = (mag_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_z_bits | ~mag_z_mask)
+        : (int64_t)mag_z_bits;
+    lightning_board_magnometer_sensor_information->mag_z = (float)(mag_z_raw / 1000);
+}
+
+void receive_lightning_pulse_message(const can_msg_t *message, lightning_pulse_message_t *lightning_pulse_message) {
+    
+    uint32_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 4);
+    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t count_mask = (1ULL << 32) - 1ULL;
+    uint64_t count_raw = (data >> 0) & count_mask;
+    lightning_pulse_message->count = (uint32_t)count_raw;
+}
+
+void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env) {
+    
+    uint32_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 4);
+    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t temp_raw = (data >> 16) & temp_mask;
+    front_msb_env->temp = (float)(temp_raw / 10);
+    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
+    uint64_t humidity_raw = (data >> 0) & humidity_mask;
+    front_msb_env->humidity = (float)(humidity_raw / 10);
+}
+
+void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_force_bits = (data >> 48) & x_force_mask;
+    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_force_bits | ~x_force_mask)
+        : (int64_t)x_force_bits;
+    front_msb_accel->x_force = (float)x_force_raw;
+    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_force_bits = (data >> 32) & y_force_mask;
+    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_force_bits | ~y_force_mask)
+        : (int64_t)y_force_bits;
+    front_msb_accel->y_force = (float)y_force_raw;
+    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_force_bits = (data >> 16) & z_force_mask;
+    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_force_bits | ~z_force_mask)
+        : (int64_t)z_force_bits;
+    front_msb_accel->z_force = (float)z_force_raw;
+}
+
+void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
+    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_deg_bits | ~x_deg_mask)
+        : (int64_t)x_deg_bits;
+    front_msb_gyro->x_deg = (float)x_deg_raw;
+    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
+    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_deg_bits | ~y_deg_mask)
+        : (int64_t)y_deg_bits;
+    front_msb_gyro->y_deg = (float)y_deg_raw;
+    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
+    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_deg_bits | ~z_deg_mask)
+        : (int64_t)z_deg_bits;
+    front_msb_gyro->z_deg = (float)z_deg_raw;
+}
+
+void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain1_raw = (data >> 32) & strain1_mask;
+    front_msb_strain->strain1 = (uint32_t)strain1_raw;
+    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain2_raw = (data >> 0) & strain2_mask;
+    front_msb_strain->strain2 = (uint32_t)strain2_raw;
+}
+
+void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot) {
+    
+    struct __attribute__((__packed__)) {
+        uint32_t shock1;
+        uint16_t shock1_raw;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    
+    front_shockpot->shock1 = (float)bitstream_data.shock1;
+    
+    
+    
+    
+    
+    front_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
+    
+    
+    
+}
+
+void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t rh_mask = (1ULL << 16) - 1ULL;
+    uint64_t rh_bits = (data >> 0) & rh_mask;
+    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(rh_bits | ~rh_mask)
+        : (int64_t)rh_bits;
+    front_ride_height->rh = (float)rh_raw;
+}
+
+void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
+    front_wheel_temp->wheel_temp = (float)wheel_temp_raw;
+}
+
+void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
+    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
+        : (int64_t)x_fdeg_bits;
+    front_msb_orientation->x_fdeg = (float)x_fdeg_raw;
+    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
+    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
+        : (int64_t)y_fdeg_bits;
+    front_msb_orientation->y_fdeg = (float)y_fdeg_raw;
+    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
+    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
+        : (int64_t)z_fdeg_bits;
+    front_msb_orientation->z_fdeg = (float)z_fdeg_raw;
+}
+
+void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env) {
+    
+    uint32_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 4);
+    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t temp_raw = (data >> 16) & temp_mask;
+    back_msb_env->temp = (float)(temp_raw / 10);
+    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
+    uint64_t humidity_raw = (data >> 0) & humidity_mask;
+    back_msb_env->humidity = (float)(humidity_raw / 10);
+}
+
+void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_force_bits = (data >> 48) & x_force_mask;
+    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_force_bits | ~x_force_mask)
+        : (int64_t)x_force_bits;
+    back_msb_accel->x_force = (float)x_force_raw;
+    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_force_bits = (data >> 32) & y_force_mask;
+    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_force_bits | ~y_force_mask)
+        : (int64_t)y_force_bits;
+    back_msb_accel->y_force = (float)y_force_raw;
+    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_force_bits = (data >> 16) & z_force_mask;
+    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_force_bits | ~z_force_mask)
+        : (int64_t)z_force_bits;
+    back_msb_accel->z_force = (float)z_force_raw;
+}
+
+void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
+    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_deg_bits | ~x_deg_mask)
+        : (int64_t)x_deg_bits;
+    back_msb_gyro->x_deg = (float)x_deg_raw;
+    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
+    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_deg_bits | ~y_deg_mask)
+        : (int64_t)y_deg_bits;
+    back_msb_gyro->y_deg = (float)y_deg_raw;
+    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
+    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_deg_bits | ~z_deg_mask)
+        : (int64_t)z_deg_bits;
+    back_msb_gyro->z_deg = (float)z_deg_raw;
+}
+
+void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain1_raw = (data >> 32) & strain1_mask;
+    back_msb_strain->strain1 = (uint32_t)strain1_raw;
+    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain2_raw = (data >> 0) & strain2_mask;
+    back_msb_strain->strain2 = (uint32_t)strain2_raw;
+}
+
+void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot) {
+    
+    struct __attribute__((__packed__)) {
+        uint32_t shock1;
+        uint16_t shock1_raw;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    
+    back_shockpot->shock1 = (float)bitstream_data.shock1;
+    
+    
+    
+    
+    
+    back_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
+    
+    
+    
+}
+
+void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t rh_mask = (1ULL << 16) - 1ULL;
+    uint64_t rh_bits = (data >> 0) & rh_mask;
+    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(rh_bits | ~rh_mask)
+        : (int64_t)rh_bits;
+    back_ride_height->rh = (float)rh_raw;
+}
+
+void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
+    back_wheel_temp->wheel_temp = (float)wheel_temp_raw;
+}
+
+void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
+    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
+        : (int64_t)x_fdeg_bits;
+    back_msb_orientation->x_fdeg = (float)x_fdeg_raw;
+    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
+    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
+        : (int64_t)y_fdeg_bits;
+    back_msb_orientation->y_fdeg = (float)y_fdeg_raw;
+    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
+    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
+        : (int64_t)z_fdeg_bits;
+    back_msb_orientation->z_fdeg = (float)z_fdeg_raw;
+}
+
+void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information) {
+    
+    struct __attribute__((__packed__)) {
+        uint16_t R_iso_corrected;
+        uint8_t R_iso_status;
+        uint8_t Iso_measurement_counter;
+        uint8_t device_error;
+        uint8_t HV_pos_conn_fail;
+        uint8_t HV_neg_conn_fail;
+        uint8_t Earth_conn_fail;
+        uint8_t Iso_alarm;
+        uint8_t iso_warning;
+        uint8_t iso_outdated;
+        uint8_t Unbalance_alarm;
+        uint8_t Undervoltage_alarm;
+        uint8_t Unsafe_to_start;
+        uint8_t Earthlift_Open;
+        uint8_t warnings_and_alarms_unused_bits;
+        uint8_t Device_Activity;
+        uint8_t Not_Applicable;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    
+    imd_general_information->R_iso_corrected = (uint16_t)bitstream_data.R_iso_corrected;
+    
+    
+    
+    
+    
+    imd_general_information->R_iso_status = (uint8_t)bitstream_data.R_iso_status;
+    
+    
+    
+    
+    
+    imd_general_information->Iso_measurement_counter = (uint8_t)bitstream_data.Iso_measurement_counter;
+    
+    
+    
+    
+    
+    imd_general_information->device_error = (bool)bitstream_data.device_error;
+    
+    
+    
+    
+    
+    imd_general_information->HV_pos_conn_fail = (bool)bitstream_data.HV_pos_conn_fail;
+    
+    
+    
+    
+    
+    imd_general_information->HV_neg_conn_fail = (bool)bitstream_data.HV_neg_conn_fail;
+    
+    
+    
+    
+    
+    imd_general_information->Earth_conn_fail = (bool)bitstream_data.Earth_conn_fail;
+    
+    
+    
+    
+    
+    imd_general_information->Iso_alarm = (bool)bitstream_data.Iso_alarm;
+    
+    
+    
+    
+    
+    imd_general_information->iso_warning = (bool)bitstream_data.iso_warning;
+    
+    
+    
+    
+    
+    imd_general_information->iso_outdated = (bool)bitstream_data.iso_outdated;
+    
+    
+    
+    
+    
+    imd_general_information->Unbalance_alarm = (bool)bitstream_data.Unbalance_alarm;
+    
+    
+    
+    
+    
+    imd_general_information->Undervoltage_alarm = (bool)bitstream_data.Undervoltage_alarm;
+    
+    
+    
+    
+    
+    imd_general_information->Unsafe_to_start = (bool)bitstream_data.Unsafe_to_start;
+    
+    
+    
+    
+    
+    
+    
 }
 

--- a/Core/Src/can_messages_rx.c
+++ b/Core/Src/can_messages_rx.c
@@ -1,39 +1,5 @@
 #include "can_messages_rx.h"
 
-void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t current_target_ac_mask = (1ULL << 16) - 1ULL;
-    uint64_t current_target_ac_bits = (data >> 0) & current_target_ac_mask;
-    int64_t current_target_ac_raw = (current_target_ac_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(current_target_ac_bits | ~current_target_ac_mask)
-        : (int64_t)current_target_ac_bits;
-    ac_current_command->current_target_ac = (float)(current_target_ac_raw / 10);
-}
-
-void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t brake_ac_current_mask = (1ULL << 16) - 1ULL;
-    uint64_t brake_ac_current_bits = (data >> 48) & brake_ac_current_mask;
-    int64_t brake_ac_current_raw = (brake_ac_current_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(brake_ac_current_bits | ~brake_ac_current_mask)
-        : (int64_t)brake_ac_current_bits;
-    brake_current_command->brake_ac_current = (float)(brake_ac_current_raw / 10);
-}
-
-void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command) {
-    
-    uint8_t data = message->data[0];
-    uint64_t drive_enable_mask = (1ULL << 8) - 1ULL;
-    uint64_t drive_enable_raw = (data >> 0) & drive_enable_mask;
-    drive_enable_command->drive_enable = (uint8_t)drive_enable_raw;
-}
-
 void receive_shepherd_bms_fan_percent(const can_msg_t *message, shepherd_bms_fan_percent_t *shepherd_bms_fan_percent) {
     
     uint8_t data = message->data[0];
@@ -136,6 +102,491 @@ void receive_rtds_command_message(const can_msg_t *message, rtds_command_message
     uint64_t command_mask = (1ULL << 8) - 1ULL;
     uint64_t command_raw = (data >> 0) & command_mask;
     rtds_command_message->command = (uint8_t)command_raw;
+}
+
+void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons) {
+    
+    uint8_t data = message->data[0];
+    uint64_t button_id_mask = (1ULL << 8) - 1ULL;
+    uint64_t button_id_raw = (data >> 0) & button_id_mask;
+    wheel_buttons->button_id = (uint8_t)button_id_raw;
+}
+
+void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information) {
+    
+    struct __attribute__((__packed__)) {
+        uint16_t R_iso_corrected;
+        uint8_t R_iso_status;
+        uint8_t Iso_measurement_counter;
+        uint8_t device_error;
+        uint8_t HV_pos_conn_fail;
+        uint8_t HV_neg_conn_fail;
+        uint8_t Earth_conn_fail;
+        uint8_t Iso_alarm;
+        uint8_t iso_warning;
+        uint8_t iso_outdated;
+        uint8_t Unbalance_alarm;
+        uint8_t Undervoltage_alarm;
+        uint8_t Unsafe_to_start;
+        uint8_t Earthlift_Open;
+        uint8_t warnings_and_alarms_unused_bits;
+        uint8_t Device_Activity;
+        uint8_t Not_Applicable;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    imd_general_information->R_iso_corrected = (uint16_t)bitstream_data.R_iso_corrected;
+    
+    
+    
+    imd_general_information->R_iso_status = (uint8_t)bitstream_data.R_iso_status;
+    
+    
+    
+    imd_general_information->Iso_measurement_counter = (uint8_t)bitstream_data.Iso_measurement_counter;
+    
+    
+    
+    imd_general_information->device_error = (bool)bitstream_data.device_error;
+    
+    
+    
+    imd_general_information->HV_pos_conn_fail = (bool)bitstream_data.HV_pos_conn_fail;
+    
+    
+    
+    imd_general_information->HV_neg_conn_fail = (bool)bitstream_data.HV_neg_conn_fail;
+    
+    
+    
+    imd_general_information->Earth_conn_fail = (bool)bitstream_data.Earth_conn_fail;
+    
+    
+    
+    imd_general_information->Iso_alarm = (bool)bitstream_data.Iso_alarm;
+    
+    
+    
+    imd_general_information->iso_warning = (bool)bitstream_data.iso_warning;
+    
+    
+    
+    imd_general_information->iso_outdated = (bool)bitstream_data.iso_outdated;
+    
+    
+    
+    imd_general_information->Unbalance_alarm = (bool)bitstream_data.Unbalance_alarm;
+    
+    
+    
+    imd_general_information->Undervoltage_alarm = (bool)bitstream_data.Undervoltage_alarm;
+    
+    
+    
+    imd_general_information->Unsafe_to_start = (bool)bitstream_data.Unsafe_to_start;
+    
+    
+    
+    imd_general_information->Earthlift_Open = (bool)bitstream_data.Earthlift_Open;
+    
+    
+    
+    imd_general_information->warnings_and_alarms_unused_bits = (uint8_t)bitstream_data.warnings_and_alarms_unused_bits;
+    
+    
+    
+    imd_general_information->Device_Activity = (uint8_t)bitstream_data.Device_Activity;
+    
+    
+    
+    imd_general_information->Not_Applicable = (uint8_t)bitstream_data.Not_Applicable;
+    
+    
+}
+
+void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env) {
+    
+    uint32_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 4);
+    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t temp_raw = (data >> 16) & temp_mask;
+    front_msb_env->temp = (float)(temp_raw / 10);
+    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
+    uint64_t humidity_raw = (data >> 0) & humidity_mask;
+    front_msb_env->humidity = (float)(humidity_raw / 10);
+}
+
+void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_force_bits = (data >> 48) & x_force_mask;
+    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_force_bits | ~x_force_mask)
+        : (int64_t)x_force_bits;
+    front_msb_accel->x_force = (float)x_force_raw;
+    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_force_bits = (data >> 32) & y_force_mask;
+    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_force_bits | ~y_force_mask)
+        : (int64_t)y_force_bits;
+    front_msb_accel->y_force = (float)y_force_raw;
+    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_force_bits = (data >> 16) & z_force_mask;
+    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_force_bits | ~z_force_mask)
+        : (int64_t)z_force_bits;
+    front_msb_accel->z_force = (float)z_force_raw;
+}
+
+void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
+    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_deg_bits | ~x_deg_mask)
+        : (int64_t)x_deg_bits;
+    front_msb_gyro->x_deg = (float)x_deg_raw;
+    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
+    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_deg_bits | ~y_deg_mask)
+        : (int64_t)y_deg_bits;
+    front_msb_gyro->y_deg = (float)y_deg_raw;
+    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
+    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_deg_bits | ~z_deg_mask)
+        : (int64_t)z_deg_bits;
+    front_msb_gyro->z_deg = (float)z_deg_raw;
+}
+
+void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain1_raw = (data >> 32) & strain1_mask;
+    front_msb_strain->strain1 = (uint32_t)strain1_raw;
+    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain2_raw = (data >> 0) & strain2_mask;
+    front_msb_strain->strain2 = (uint32_t)strain2_raw;
+}
+
+void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot) {
+    
+    struct __attribute__((__packed__)) {
+        uint32_t shock1;
+        uint16_t shock1_raw;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    front_shockpot->shock1 = (float)bitstream_data.shock1;
+    
+    
+    
+    front_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
+    
+    
+}
+
+void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t rh_mask = (1ULL << 16) - 1ULL;
+    uint64_t rh_bits = (data >> 0) & rh_mask;
+    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(rh_bits | ~rh_mask)
+        : (int64_t)rh_bits;
+    front_ride_height->rh = (float)rh_raw;
+}
+
+void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
+    front_wheel_temp->wheel_temp = (float)wheel_temp_raw;
+}
+
+void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
+    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
+        : (int64_t)x_fdeg_bits;
+    front_msb_orientation->x_fdeg = (float)x_fdeg_raw;
+    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
+    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
+        : (int64_t)y_fdeg_bits;
+    front_msb_orientation->y_fdeg = (float)y_fdeg_raw;
+    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
+    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
+        : (int64_t)z_fdeg_bits;
+    front_msb_orientation->z_fdeg = (float)z_fdeg_raw;
+}
+
+void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env) {
+    
+    uint32_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 4);
+    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t temp_raw = (data >> 16) & temp_mask;
+    back_msb_env->temp = (float)(temp_raw / 10);
+    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
+    uint64_t humidity_raw = (data >> 0) & humidity_mask;
+    back_msb_env->humidity = (float)(humidity_raw / 10);
+}
+
+void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_force_bits = (data >> 48) & x_force_mask;
+    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_force_bits | ~x_force_mask)
+        : (int64_t)x_force_bits;
+    back_msb_accel->x_force = (float)x_force_raw;
+    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_force_bits = (data >> 32) & y_force_mask;
+    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_force_bits | ~y_force_mask)
+        : (int64_t)y_force_bits;
+    back_msb_accel->y_force = (float)y_force_raw;
+    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_force_bits = (data >> 16) & z_force_mask;
+    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_force_bits | ~z_force_mask)
+        : (int64_t)z_force_bits;
+    back_msb_accel->z_force = (float)z_force_raw;
+}
+
+void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
+    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_deg_bits | ~x_deg_mask)
+        : (int64_t)x_deg_bits;
+    back_msb_gyro->x_deg = (float)x_deg_raw;
+    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
+    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_deg_bits | ~y_deg_mask)
+        : (int64_t)y_deg_bits;
+    back_msb_gyro->y_deg = (float)y_deg_raw;
+    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
+    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_deg_bits | ~z_deg_mask)
+        : (int64_t)z_deg_bits;
+    back_msb_gyro->z_deg = (float)z_deg_raw;
+}
+
+void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain1_raw = (data >> 32) & strain1_mask;
+    back_msb_strain->strain1 = (uint32_t)strain1_raw;
+    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
+    uint64_t strain2_raw = (data >> 0) & strain2_mask;
+    back_msb_strain->strain2 = (uint32_t)strain2_raw;
+}
+
+void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot) {
+    
+    struct __attribute__((__packed__)) {
+        uint32_t shock1;
+        uint16_t shock1_raw;
+        
+    } bitstream_data;
+
+    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
+
+    
+    
+    back_shockpot->shock1 = (float)bitstream_data.shock1;
+    
+    
+    
+    back_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
+    
+    
+}
+
+void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t rh_mask = (1ULL << 16) - 1ULL;
+    uint64_t rh_bits = (data >> 0) & rh_mask;
+    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(rh_bits | ~rh_mask)
+        : (int64_t)rh_bits;
+    back_ride_height->rh = (float)rh_raw;
+}
+
+void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp) {
+    
+    uint16_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 2);
+    uint16_t data = __builtin_bswap16(data_bigendian);
+    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
+    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
+    back_wheel_temp->wheel_temp = (float)wheel_temp_raw;
+}
+
+void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
+    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
+        : (int64_t)x_fdeg_bits;
+    back_msb_orientation->x_fdeg = (float)x_fdeg_raw;
+    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
+    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
+        : (int64_t)y_fdeg_bits;
+    back_msb_orientation->y_fdeg = (float)y_fdeg_raw;
+    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
+    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
+    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
+        : (int64_t)z_fdeg_bits;
+    back_msb_orientation->z_fdeg = (float)z_fdeg_raw;
+}
+
+void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t accel_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_x_bits = (data >> 48) & accel_x_mask;
+    int64_t accel_x_raw = (accel_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_x_bits | ~accel_x_mask)
+        : (int64_t)accel_x_bits;
+    lightning_board_imu_acceleration_data->accel_x = (float)(accel_x_raw / 1000);
+    uint64_t accel_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_y_bits = (data >> 32) & accel_y_mask;
+    int64_t accel_y_raw = (accel_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_y_bits | ~accel_y_mask)
+        : (int64_t)accel_y_bits;
+    lightning_board_imu_acceleration_data->accel_y = (float)(accel_y_raw / 1000);
+    uint64_t accel_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t accel_z_bits = (data >> 16) & accel_z_mask;
+    int64_t accel_z_raw = (accel_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(accel_z_bits | ~accel_z_mask)
+        : (int64_t)accel_z_bits;
+    lightning_board_imu_acceleration_data->accel_z = (float)(accel_z_raw / 1000);
+}
+
+void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t gyro_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_x_bits = (data >> 48) & gyro_x_mask;
+    int64_t gyro_x_raw = (gyro_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_x_bits | ~gyro_x_mask)
+        : (int64_t)gyro_x_bits;
+    lightning_board_imu_gyro_data->gyro_x = (float)(gyro_x_raw / 1000);
+    uint64_t gyro_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_y_bits = (data >> 32) & gyro_y_mask;
+    int64_t gyro_y_raw = (gyro_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_y_bits | ~gyro_y_mask)
+        : (int64_t)gyro_y_bits;
+    lightning_board_imu_gyro_data->gyro_y = (float)(gyro_y_raw / 1000);
+    uint64_t gyro_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t gyro_z_bits = (data >> 16) & gyro_z_mask;
+    int64_t gyro_z_raw = (gyro_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(gyro_z_bits | ~gyro_z_mask)
+        : (int64_t)gyro_z_bits;
+    lightning_board_imu_gyro_data->gyro_z = (float)(gyro_z_raw / 1000);
+}
+
+void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t interrupt_mask = (1ULL << 8) - 1ULL;
+    uint64_t interrupt_raw = (data >> 56) & interrupt_mask;
+    lightning_board_lightning_sensor_information->interrupt = (uint8_t)interrupt_raw;
+    uint64_t distance_mask = (1ULL << 8) - 1ULL;
+    uint64_t distance_raw = (data >> 48) & distance_mask;
+    lightning_board_lightning_sensor_information->distance = (uint8_t)distance_raw;
+    uint64_t energy_mask = (1ULL << 32) - 1ULL;
+    uint64_t energy_raw = (data >> 16) & energy_mask;
+    lightning_board_lightning_sensor_information->energy = (uint32_t)energy_raw;
+}
+
+void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information) {
+    
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
+    uint64_t mag_x_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_x_bits = (data >> 48) & mag_x_mask;
+    int64_t mag_x_raw = (mag_x_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_x_bits | ~mag_x_mask)
+        : (int64_t)mag_x_bits;
+    lightning_board_magnometer_sensor_information->mag_x = (float)(mag_x_raw / 1000);
+    uint64_t mag_y_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_y_bits = (data >> 32) & mag_y_mask;
+    int64_t mag_y_raw = (mag_y_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_y_bits | ~mag_y_mask)
+        : (int64_t)mag_y_bits;
+    lightning_board_magnometer_sensor_information->mag_y = (float)(mag_y_raw / 1000);
+    uint64_t mag_z_mask = (1ULL << 16) - 1ULL;
+    uint64_t mag_z_bits = (data >> 16) & mag_z_mask;
+    int64_t mag_z_raw = (mag_z_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(mag_z_bits | ~mag_z_mask)
+        : (int64_t)mag_z_bits;
+    lightning_board_magnometer_sensor_information->mag_z = (float)(mag_z_raw / 1000);
 }
 
 void receive_dashboard_efuse(const can_msg_t *message, dashboard_efuse_t *dashboard_efuse) {
@@ -495,15 +946,21 @@ void receive_car_state(const can_msg_t *message, car_state_t *car_state) {
 
 void receive_pedal_percent_pressed_values(const can_msg_t *message, pedal_percent_pressed_values_t *pedal_percent_pressed_values) {
     
-    uint32_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 4);
-    uint32_t data = __builtin_bswap32(data_bigendian);
+    uint64_t data_bigendian;
+    memcpy(&data_bigendian, message->data, 8);
+    uint64_t data = __builtin_bswap64(data_bigendian);
     uint64_t accel_norm_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_norm_raw = (data >> 16) & accel_norm_mask;
+    uint64_t accel_norm_raw = (data >> 48) & accel_norm_mask;
     pedal_percent_pressed_values->accel_norm = (float)(accel_norm_raw / 100);
     uint64_t brake_norm_mask = (1ULL << 16) - 1ULL;
-    uint64_t brake_norm_raw = (data >> 0) & brake_norm_mask;
+    uint64_t brake_norm_raw = (data >> 32) & brake_norm_mask;
     pedal_percent_pressed_values->brake_norm = (float)(brake_norm_raw / 100);
+    uint64_t brake_psi_mask = (1ULL << 16) - 1ULL;
+    uint64_t brake_psi_bits = (data >> 16) & brake_psi_mask;
+    int64_t brake_psi_raw = (brake_psi_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(brake_psi_bits | ~brake_psi_mask)
+        : (int64_t)brake_psi_bits;
+    pedal_percent_pressed_values->brake_psi = (float)(brake_psi_raw / 10);
 }
 
 void receive_pedal_sensor_voltages(const can_msg_t *message, pedal_sensor_voltages_t *pedal_sensor_voltages) {
@@ -837,488 +1294,63 @@ void receive_bms_shutdown_status_as_reported_by_vcu(const can_msg_t *message, bm
     bms_shutdown_status_as_reported_by_vcu->bms_shutdown_as_reported_by_vcu = (bool)bms_shutdown_as_reported_by_vcu_raw;
 }
 
-void receive_wheel_buttons(const can_msg_t *message, wheel_buttons_t *wheel_buttons) {
+void receive_drive_lock_states(const can_msg_t *message, drive_lock_states_t *drive_lock_states) {
     
     uint8_t data = message->data[0];
-    uint64_t button_id_mask = (1ULL << 8) - 1ULL;
-    uint64_t button_id_raw = (data >> 0) & button_id_mask;
-    wheel_buttons->button_id = (uint8_t)button_id_raw;
+    uint64_t BRAKE_OC_mask = (1ULL << 1) - 1ULL;
+    uint64_t BRAKE_OC_raw = (data >> 7) & BRAKE_OC_mask;
+    drive_lock_states->BRAKE_OC = (bool)BRAKE_OC_raw;
+    uint64_t BRAKE_SC_mask = (1ULL << 1) - 1ULL;
+    uint64_t BRAKE_SC_raw = (data >> 6) & BRAKE_SC_mask;
+    drive_lock_states->BRAKE_SC = (bool)BRAKE_SC_raw;
+    uint64_t ACCEL_OC_mask = (1ULL << 1) - 1ULL;
+    uint64_t ACCEL_OC_raw = (data >> 5) & ACCEL_OC_mask;
+    drive_lock_states->ACCEL_OC = (bool)ACCEL_OC_raw;
+    uint64_t ACCEL_SC_mask = (1ULL << 1) - 1ULL;
+    uint64_t ACCEL_SC_raw = (data >> 4) & ACCEL_SC_mask;
+    drive_lock_states->ACCEL_SC = (bool)ACCEL_SC_raw;
+    uint64_t ACCEL_DIFF_mask = (1ULL << 1) - 1ULL;
+    uint64_t ACCEL_DIFF_raw = (data >> 3) & ACCEL_DIFF_mask;
+    drive_lock_states->ACCEL_DIFF = (bool)ACCEL_DIFF_raw;
+    uint64_t BSPD_PREF_mask = (1ULL << 1) - 1ULL;
+    uint64_t BSPD_PREF_raw = (data >> 2) & BSPD_PREF_mask;
+    drive_lock_states->BSPD_PREF = (bool)BSPD_PREF_raw;
+    uint64_t empty_mask = (1ULL << 2) - 1ULL;
+    uint64_t empty_raw = (data >> 0) & empty_mask;
+    drive_lock_states->empty = ()empty_raw;
 }
 
-void receive_lightning_board_imu_acceleration_data(const can_msg_t *message, lightning_board_imu_acceleration_data_t *lightning_board_imu_acceleration_data) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t accel_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_x_bits = (data >> 48) & accel_x_mask;
-    int64_t accel_x_raw = (accel_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_x_bits | ~accel_x_mask)
-        : (int64_t)accel_x_bits;
-    lightning_board_imu_acceleration_data->accel_x = (float)(accel_x_raw / 1000);
-    uint64_t accel_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_y_bits = (data >> 32) & accel_y_mask;
-    int64_t accel_y_raw = (accel_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_y_bits | ~accel_y_mask)
-        : (int64_t)accel_y_bits;
-    lightning_board_imu_acceleration_data->accel_y = (float)(accel_y_raw / 1000);
-    uint64_t accel_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t accel_z_bits = (data >> 16) & accel_z_mask;
-    int64_t accel_z_raw = (accel_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(accel_z_bits | ~accel_z_mask)
-        : (int64_t)accel_z_bits;
-    lightning_board_imu_acceleration_data->accel_z = (float)(accel_z_raw / 1000);
-}
-
-void receive_lightning_board_imu_gyro_data(const can_msg_t *message, lightning_board_imu_gyro_data_t *lightning_board_imu_gyro_data) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t gyro_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_x_bits = (data >> 48) & gyro_x_mask;
-    int64_t gyro_x_raw = (gyro_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_x_bits | ~gyro_x_mask)
-        : (int64_t)gyro_x_bits;
-    lightning_board_imu_gyro_data->gyro_x = (float)(gyro_x_raw / 1000);
-    uint64_t gyro_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_y_bits = (data >> 32) & gyro_y_mask;
-    int64_t gyro_y_raw = (gyro_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_y_bits | ~gyro_y_mask)
-        : (int64_t)gyro_y_bits;
-    lightning_board_imu_gyro_data->gyro_y = (float)(gyro_y_raw / 1000);
-    uint64_t gyro_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t gyro_z_bits = (data >> 16) & gyro_z_mask;
-    int64_t gyro_z_raw = (gyro_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(gyro_z_bits | ~gyro_z_mask)
-        : (int64_t)gyro_z_bits;
-    lightning_board_imu_gyro_data->gyro_z = (float)(gyro_z_raw / 1000);
-}
-
-void receive_lightning_board_lightning_sensor_information(const can_msg_t *message, lightning_board_lightning_sensor_information_t *lightning_board_lightning_sensor_information) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t interrupt_mask = (1ULL << 8) - 1ULL;
-    uint64_t interrupt_raw = (data >> 56) & interrupt_mask;
-    lightning_board_lightning_sensor_information->interrupt = (uint8_t)interrupt_raw;
-    uint64_t distance_mask = (1ULL << 8) - 1ULL;
-    uint64_t distance_raw = (data >> 48) & distance_mask;
-    lightning_board_lightning_sensor_information->distance = (uint8_t)distance_raw;
-    uint64_t energy_mask = (1ULL << 32) - 1ULL;
-    uint64_t energy_raw = (data >> 16) & energy_mask;
-    lightning_board_lightning_sensor_information->energy = (uint32_t)energy_raw;
-}
-
-void receive_lightning_board_magnometer_sensor_information(const can_msg_t *message, lightning_board_magnometer_sensor_information_t *lightning_board_magnometer_sensor_information) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t mag_x_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_x_bits = (data >> 48) & mag_x_mask;
-    int64_t mag_x_raw = (mag_x_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_x_bits | ~mag_x_mask)
-        : (int64_t)mag_x_bits;
-    lightning_board_magnometer_sensor_information->mag_x = (float)(mag_x_raw / 1000);
-    uint64_t mag_y_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_y_bits = (data >> 32) & mag_y_mask;
-    int64_t mag_y_raw = (mag_y_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_y_bits | ~mag_y_mask)
-        : (int64_t)mag_y_bits;
-    lightning_board_magnometer_sensor_information->mag_y = (float)(mag_y_raw / 1000);
-    uint64_t mag_z_mask = (1ULL << 16) - 1ULL;
-    uint64_t mag_z_bits = (data >> 16) & mag_z_mask;
-    int64_t mag_z_raw = (mag_z_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(mag_z_bits | ~mag_z_mask)
-        : (int64_t)mag_z_bits;
-    lightning_board_magnometer_sensor_information->mag_z = (float)(mag_z_raw / 1000);
-}
-
-void receive_front_msb_env(const can_msg_t *message, front_msb_env_t *front_msb_env) {
-    
-    uint32_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 4);
-    uint32_t data = __builtin_bswap32(data_bigendian);
-    uint64_t temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t temp_raw = (data >> 16) & temp_mask;
-    front_msb_env->temp = (float)(temp_raw / 10);
-    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
-    uint64_t humidity_raw = (data >> 0) & humidity_mask;
-    front_msb_env->humidity = (float)(humidity_raw / 10);
-}
-
-void receive_front_msb_accel(const can_msg_t *message, front_msb_accel_t *front_msb_accel) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_force_bits = (data >> 48) & x_force_mask;
-    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_force_bits | ~x_force_mask)
-        : (int64_t)x_force_bits;
-    front_msb_accel->x_force = (float)x_force_raw;
-    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_force_bits = (data >> 32) & y_force_mask;
-    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_force_bits | ~y_force_mask)
-        : (int64_t)y_force_bits;
-    front_msb_accel->y_force = (float)y_force_raw;
-    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_force_bits = (data >> 16) & z_force_mask;
-    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_force_bits | ~z_force_mask)
-        : (int64_t)z_force_bits;
-    front_msb_accel->z_force = (float)z_force_raw;
-}
-
-void receive_front_msb_gyro(const can_msg_t *message, front_msb_gyro_t *front_msb_gyro) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
-    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_deg_bits | ~x_deg_mask)
-        : (int64_t)x_deg_bits;
-    front_msb_gyro->x_deg = (float)x_deg_raw;
-    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
-    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_deg_bits | ~y_deg_mask)
-        : (int64_t)y_deg_bits;
-    front_msb_gyro->y_deg = (float)y_deg_raw;
-    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
-    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_deg_bits | ~z_deg_mask)
-        : (int64_t)z_deg_bits;
-    front_msb_gyro->z_deg = (float)z_deg_raw;
-}
-
-void receive_front_msb_strain(const can_msg_t *message, front_msb_strain_t *front_msb_strain) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain1_raw = (data >> 32) & strain1_mask;
-    front_msb_strain->strain1 = (uint32_t)strain1_raw;
-    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain2_raw = (data >> 0) & strain2_mask;
-    front_msb_strain->strain2 = (uint32_t)strain2_raw;
-}
-
-void receive_front_shockpot(const can_msg_t *message, front_shockpot_t *front_shockpot) {
-    
-    struct __attribute__((__packed__)) {
-        uint32_t shock1;
-        uint16_t shock1_raw;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    front_shockpot->shock1 = (float)bitstream_data.shock1;
-    
-    
-    
-    front_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
-    
-    
-}
-
-void receive_front_ride_height(const can_msg_t *message, front_ride_height_t *front_ride_height) {
+void receive_ac_current_command(const can_msg_t *message, ac_current_command_t *ac_current_command) {
     
     uint16_t data_bigendian;
     memcpy(&data_bigendian, message->data, 2);
     uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t rh_mask = (1ULL << 16) - 1ULL;
-    uint64_t rh_bits = (data >> 0) & rh_mask;
-    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(rh_bits | ~rh_mask)
-        : (int64_t)rh_bits;
-    front_ride_height->rh = (float)rh_raw;
+    uint64_t current_target_ac_mask = (1ULL << 16) - 1ULL;
+    uint64_t current_target_ac_bits = (data >> 0) & current_target_ac_mask;
+    int64_t current_target_ac_raw = (current_target_ac_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(current_target_ac_bits | ~current_target_ac_mask)
+        : (int64_t)current_target_ac_bits;
+    ac_current_command->current_target_ac = (float)(current_target_ac_raw / 10);
 }
 
-void receive_front_wheel_temp(const can_msg_t *message, front_wheel_temp_t *front_wheel_temp) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
-    front_wheel_temp->wheel_temp = (float)wheel_temp_raw;
-}
-
-void receive_front_msb_orientation(const can_msg_t *message, front_msb_orientation_t *front_msb_orientation) {
+void receive_brake_current_command(const can_msg_t *message, brake_current_command_t *brake_current_command) {
     
     uint64_t data_bigendian;
     memcpy(&data_bigendian, message->data, 8);
     uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
-    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
-        : (int64_t)x_fdeg_bits;
-    front_msb_orientation->x_fdeg = (float)x_fdeg_raw;
-    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
-    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
-        : (int64_t)y_fdeg_bits;
-    front_msb_orientation->y_fdeg = (float)y_fdeg_raw;
-    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
-    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
-        : (int64_t)z_fdeg_bits;
-    front_msb_orientation->z_fdeg = (float)z_fdeg_raw;
+    uint64_t brake_ac_current_mask = (1ULL << 16) - 1ULL;
+    uint64_t brake_ac_current_bits = (data >> 48) & brake_ac_current_mask;
+    int64_t brake_ac_current_raw = (brake_ac_current_bits & (1ULL << (16 - 1)))
+        ? (int64_t)(brake_ac_current_bits | ~brake_ac_current_mask)
+        : (int64_t)brake_ac_current_bits;
+    brake_current_command->brake_ac_current = (float)(brake_ac_current_raw / 10);
 }
 
-void receive_back_msb_env(const can_msg_t *message, back_msb_env_t *back_msb_env) {
-    
-    uint32_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 4);
-    uint32_t data = __builtin_bswap32(data_bigendian);
-    uint64_t temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t temp_raw = (data >> 16) & temp_mask;
-    back_msb_env->temp = (float)(temp_raw / 10);
-    uint64_t humidity_mask = (1ULL << 16) - 1ULL;
-    uint64_t humidity_raw = (data >> 0) & humidity_mask;
-    back_msb_env->humidity = (float)(humidity_raw / 10);
-}
-
-void receive_back_msb_accel(const can_msg_t *message, back_msb_accel_t *back_msb_accel) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_force_bits = (data >> 48) & x_force_mask;
-    int64_t x_force_raw = (x_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_force_bits | ~x_force_mask)
-        : (int64_t)x_force_bits;
-    back_msb_accel->x_force = (float)x_force_raw;
-    uint64_t y_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_force_bits = (data >> 32) & y_force_mask;
-    int64_t y_force_raw = (y_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_force_bits | ~y_force_mask)
-        : (int64_t)y_force_bits;
-    back_msb_accel->y_force = (float)y_force_raw;
-    uint64_t z_force_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_force_bits = (data >> 16) & z_force_mask;
-    int64_t z_force_raw = (z_force_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_force_bits | ~z_force_mask)
-        : (int64_t)z_force_bits;
-    back_msb_accel->z_force = (float)z_force_raw;
-}
-
-void receive_back_msb_gyro(const can_msg_t *message, back_msb_gyro_t *back_msb_gyro) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_deg_bits = (data >> 48) & x_deg_mask;
-    int64_t x_deg_raw = (x_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_deg_bits | ~x_deg_mask)
-        : (int64_t)x_deg_bits;
-    back_msb_gyro->x_deg = (float)x_deg_raw;
-    uint64_t y_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_deg_bits = (data >> 32) & y_deg_mask;
-    int64_t y_deg_raw = (y_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_deg_bits | ~y_deg_mask)
-        : (int64_t)y_deg_bits;
-    back_msb_gyro->y_deg = (float)y_deg_raw;
-    uint64_t z_deg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_deg_bits = (data >> 16) & z_deg_mask;
-    int64_t z_deg_raw = (z_deg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_deg_bits | ~z_deg_mask)
-        : (int64_t)z_deg_bits;
-    back_msb_gyro->z_deg = (float)z_deg_raw;
-}
-
-void receive_back_msb_strain(const can_msg_t *message, back_msb_strain_t *back_msb_strain) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t strain1_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain1_raw = (data >> 32) & strain1_mask;
-    back_msb_strain->strain1 = (uint32_t)strain1_raw;
-    uint64_t strain2_mask = (1ULL << 32) - 1ULL;
-    uint64_t strain2_raw = (data >> 0) & strain2_mask;
-    back_msb_strain->strain2 = (uint32_t)strain2_raw;
-}
-
-void receive_back_shockpot(const can_msg_t *message, back_shockpot_t *back_shockpot) {
-    
-    struct __attribute__((__packed__)) {
-        uint32_t shock1;
-        uint16_t shock1_raw;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    back_shockpot->shock1 = (float)bitstream_data.shock1;
-    
-    
-    
-    back_shockpot->shock1_raw = (uint16_t)bitstream_data.shock1_raw;
-    
-    
-}
-
-void receive_back_ride_height(const can_msg_t *message, back_ride_height_t *back_ride_height) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t rh_mask = (1ULL << 16) - 1ULL;
-    uint64_t rh_bits = (data >> 0) & rh_mask;
-    int64_t rh_raw = (rh_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(rh_bits | ~rh_mask)
-        : (int64_t)rh_bits;
-    back_ride_height->rh = (float)rh_raw;
-}
-
-void receive_back_wheel_temp(const can_msg_t *message, back_wheel_temp_t *back_wheel_temp) {
-    
-    uint16_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 2);
-    uint16_t data = __builtin_bswap16(data_bigendian);
-    uint64_t wheel_temp_mask = (1ULL << 16) - 1ULL;
-    uint64_t wheel_temp_raw = (data >> 0) & wheel_temp_mask;
-    back_wheel_temp->wheel_temp = (float)wheel_temp_raw;
-}
-
-void receive_back_msb_orientation(const can_msg_t *message, back_msb_orientation_t *back_msb_orientation) {
-    
-    uint64_t data_bigendian;
-    memcpy(&data_bigendian, message->data, 8);
-    uint64_t data = __builtin_bswap64(data_bigendian);
-    uint64_t x_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t x_fdeg_bits = (data >> 48) & x_fdeg_mask;
-    int64_t x_fdeg_raw = (x_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(x_fdeg_bits | ~x_fdeg_mask)
-        : (int64_t)x_fdeg_bits;
-    back_msb_orientation->x_fdeg = (float)x_fdeg_raw;
-    uint64_t y_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t y_fdeg_bits = (data >> 32) & y_fdeg_mask;
-    int64_t y_fdeg_raw = (y_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(y_fdeg_bits | ~y_fdeg_mask)
-        : (int64_t)y_fdeg_bits;
-    back_msb_orientation->y_fdeg = (float)y_fdeg_raw;
-    uint64_t z_fdeg_mask = (1ULL << 16) - 1ULL;
-    uint64_t z_fdeg_bits = (data >> 16) & z_fdeg_mask;
-    int64_t z_fdeg_raw = (z_fdeg_bits & (1ULL << (16 - 1)))
-        ? (int64_t)(z_fdeg_bits | ~z_fdeg_mask)
-        : (int64_t)z_fdeg_bits;
-    back_msb_orientation->z_fdeg = (float)z_fdeg_raw;
-}
-
-void receive_imd_general_information(const can_msg_t *message, imd_general_information_t *imd_general_information) {
-    
-    struct __attribute__((__packed__)) {
-        uint16_t R_iso_corrected;
-        uint8_t R_iso_status;
-        uint8_t Iso_measurement_counter;
-        uint8_t device_error;
-        uint8_t HV_pos_conn_fail;
-        uint8_t HV_neg_conn_fail;
-        uint8_t Earth_conn_fail;
-        uint8_t Iso_alarm;
-        uint8_t iso_warning;
-        uint8_t iso_outdated;
-        uint8_t Unbalance_alarm;
-        uint8_t Undervoltage_alarm;
-        uint8_t Unsafe_to_start;
-        uint8_t Earthlift_Open;
-        uint8_t warnings_and_alarms_unused_bits;
-        uint8_t Device_Activity;
-        uint8_t Not_Applicable;
-        
-    } bitstream_data;
-
-    memcpy(&bitstream_data, message->data, sizeof(bitstream_data));
-
-    
-    
-    imd_general_information->R_iso_corrected = (uint16_t)bitstream_data.R_iso_corrected;
-    
-    
-    
-    imd_general_information->R_iso_status = (uint8_t)bitstream_data.R_iso_status;
-    
-    
-    
-    imd_general_information->Iso_measurement_counter = (uint8_t)bitstream_data.Iso_measurement_counter;
-    
-    
-    
-    imd_general_information->device_error = (bool)bitstream_data.device_error;
-    
-    
-    
-    imd_general_information->HV_pos_conn_fail = (bool)bitstream_data.HV_pos_conn_fail;
-    
-    
-    
-    imd_general_information->HV_neg_conn_fail = (bool)bitstream_data.HV_neg_conn_fail;
-    
-    
-    
-    imd_general_information->Earth_conn_fail = (bool)bitstream_data.Earth_conn_fail;
-    
-    
-    
-    imd_general_information->Iso_alarm = (bool)bitstream_data.Iso_alarm;
-    
-    
-    
-    imd_general_information->iso_warning = (bool)bitstream_data.iso_warning;
-    
-    
-    
-    imd_general_information->iso_outdated = (bool)bitstream_data.iso_outdated;
-    
-    
-    
-    imd_general_information->Unbalance_alarm = (bool)bitstream_data.Unbalance_alarm;
-    
-    
-    
-    imd_general_information->Undervoltage_alarm = (bool)bitstream_data.Undervoltage_alarm;
-    
-    
-    
-    imd_general_information->Unsafe_to_start = (bool)bitstream_data.Unsafe_to_start;
-    
-    
-    
-    imd_general_information->Earthlift_Open = (bool)bitstream_data.Earthlift_Open;
-    
-    
-    
-    imd_general_information->warnings_and_alarms_unused_bits = (uint8_t)bitstream_data.warnings_and_alarms_unused_bits;
-    
-    
-    
-    imd_general_information->Device_Activity = (uint8_t)bitstream_data.Device_Activity;
-    
-    
-    
-    imd_general_information->Not_Applicable = (uint8_t)bitstream_data.Not_Applicable;
-    
-    
+void receive_drive_enable_command(const can_msg_t *message, drive_enable_command_t *drive_enable_command) {
+    
+    uint8_t data = message->data[0];
+    uint64_t drive_enable_mask = (1ULL << 8) - 1ULL;
+    uint64_t drive_enable_raw = (data >> 0) & drive_enable_mask;
+    drive_enable_command->drive_enable = (uint8_t)drive_enable_raw;
 }
 

--- a/Core/Src/can_messages_tx.c
+++ b/Core/Src/can_messages_tx.c
@@ -16,6 +16,90 @@
 static void handle_bitstream_overflow(bitstream_t *bitstream_res,
 					    uint32_t can_id);
 
+uint8_t send_max_ac_current_command
+(float max_current_ac_target)
+{
+    can_msg_t msg;
+    msg.id = 0x116;
+    msg.id_is_extended = false;
+    
+            uint64_t data = 0;
+            msg.len = 8;
+                        int32_t max_current_ac_target_i = (int32_t)(max_current_ac_target*10);
+                        if(max_current_ac_target_i > 32767) {max_current_ac_target_i = 32767;
+                        } else if(max_current_ac_target_i < -32768) {max_current_ac_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_current_ac_target_i) & 0xFFFFULL) << 48;
+            
+            uint64_t data_bigendian = __builtin_bswap64(data);
+            memcpy(msg.data, &data_bigendian, 8);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_ac_brake_current_command
+(float max_ac_brake_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x136;
+    msg.id_is_extended = false;
+    
+            uint64_t data = 0;
+            msg.len = 8;
+                        int32_t max_ac_brake_current_target_i = (int32_t)(max_ac_brake_current_target*10);
+                        if(max_ac_brake_current_target_i > 32767) {max_ac_brake_current_target_i = 32767;
+                        } else if(max_ac_brake_current_target_i < -32768) {max_ac_brake_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_ac_brake_current_target_i) & 0xFFFFULL) << 48;
+            
+            uint64_t data_bigendian = __builtin_bswap64(data);
+            memcpy(msg.data, &data_bigendian, 8);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_dc_current_command
+(float max_dc_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x156;
+    msg.id_is_extended = false;
+    
+            uint16_t data = 0;
+            msg.len = 2;
+                        int32_t max_dc_current_target_i = (int32_t)(max_dc_current_target*10);
+                        if(max_dc_current_target_i > 32767) {max_dc_current_target_i = 32767;
+                        } else if(max_dc_current_target_i < -32768) {max_dc_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_dc_current_target_i) & 0xFFFFULL) << 0;
+            
+            uint16_t data_bigendian = __builtin_bswap16(data);
+            memcpy(msg.data, &data_bigendian, 2);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_dc_brake_current_command
+(float max_dc_brake_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x176;
+    msg.id_is_extended = false;
+    
+            uint16_t data = 0;
+            msg.len = 2;
+                        int32_t max_dc_brake_current_target_i = (int32_t)(max_dc_brake_current_target*10);
+                        if(max_dc_brake_current_target_i > 32767) {max_dc_brake_current_target_i = 32767;
+                        } else if(max_dc_brake_current_target_i < -32768) {max_dc_brake_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_dc_brake_current_target_i) & 0xFFFFULL) << 0;
+            
+            uint16_t data_bigendian = __builtin_bswap16(data);
+            memcpy(msg.data, &data_bigendian, 2);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
 uint8_t send_bms_status
 (uint8_t state,float temp_average)
 {
@@ -1319,41 +1403,40 @@ uint8_t send_pack_soc_status
 }
 
 uint8_t send_shutdown_as_read_by_bms
-(bool shutdown,bool ts_minus_sense,bool ts_plus_sense,bool acc_sense,bool tsip_sense)
+(bool shutdown_state,bool shutdown_ts_minus_sense,bool shutdown_ts_plus_sense,bool shutdown_acc_sense,bool shutdown_tsip_sense)
 {
     can_msg_t msg;
     msg.id = 0x95;
     msg.id_is_extended = false;
     
-            uint64_t data = 0;
-            msg.len = 8;
-                        uint32_t shutdown_i = (uint32_t)(shutdown);
-                        if(shutdown_i > 255ULL) {shutdown_i = 255;
+            uint8_t data = 0;
+            msg.len = 1;
+                        uint32_t shutdown_state_i = (uint32_t)(shutdown_state);
+                        if(shutdown_state_i > 1ULL) {shutdown_state_i = 1;
                         }
-                        data |= ((shutdown_i) & 0xFFULL) << 56;
+                        data |= ((shutdown_state_i) & 0x1ULL) << 7;
             
-                        uint32_t ts_minus_sense_i = (uint32_t)(ts_minus_sense);
-                        if(ts_minus_sense_i > 255ULL) {ts_minus_sense_i = 255;
+                        uint32_t shutdown_ts_minus_sense_i = (uint32_t)(shutdown_ts_minus_sense);
+                        if(shutdown_ts_minus_sense_i > 1ULL) {shutdown_ts_minus_sense_i = 1;
                         }
-                        data |= ((ts_minus_sense_i) & 0xFFULL) << 48;
+                        data |= ((shutdown_ts_minus_sense_i) & 0x1ULL) << 6;
             
-                        uint32_t ts_plus_sense_i = (uint32_t)(ts_plus_sense);
-                        if(ts_plus_sense_i > 255ULL) {ts_plus_sense_i = 255;
+                        uint32_t shutdown_ts_plus_sense_i = (uint32_t)(shutdown_ts_plus_sense);
+                        if(shutdown_ts_plus_sense_i > 1ULL) {shutdown_ts_plus_sense_i = 1;
                         }
-                        data |= ((ts_plus_sense_i) & 0xFFULL) << 40;
+                        data |= ((shutdown_ts_plus_sense_i) & 0x1ULL) << 5;
             
-                        uint32_t acc_sense_i = (uint32_t)(acc_sense);
-                        if(acc_sense_i > 255ULL) {acc_sense_i = 255;
+                        uint32_t shutdown_acc_sense_i = (uint32_t)(shutdown_acc_sense);
+                        if(shutdown_acc_sense_i > 1ULL) {shutdown_acc_sense_i = 1;
                         }
-                        data |= ((acc_sense_i) & 0xFFULL) << 32;
+                        data |= ((shutdown_acc_sense_i) & 0x1ULL) << 4;
             
-                        uint32_t tsip_sense_i = (uint32_t)(tsip_sense);
-                        if(tsip_sense_i > 255ULL) {tsip_sense_i = 255;
+                        uint32_t shutdown_tsip_sense_i = (uint32_t)(shutdown_tsip_sense);
+                        if(shutdown_tsip_sense_i > 1ULL) {shutdown_tsip_sense_i = 1;
                         }
-                        data |= ((tsip_sense_i) & 0xFFULL) << 24;
+                        data |= ((shutdown_tsip_sense_i) & 0x1ULL) << 3;
             
-            uint64_t data_bigendian = __builtin_bswap64(data);
-            memcpy(msg.data, &data_bigendian, 8);
+            msg.data[0] = data;
 
     return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
 }
@@ -1431,90 +1514,6 @@ uint8_t send_bms_charge_message_send
             
             uint64_t data_bigendian = __builtin_bswap64(data);
             memcpy(msg.data, &data_bigendian, 8);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_ac_current_command
-(float max_current_ac_target)
-{
-    can_msg_t msg;
-    msg.id = 0x116;
-    msg.id_is_extended = false;
-    
-            uint64_t data = 0;
-            msg.len = 8;
-                        int32_t max_current_ac_target_i = (int32_t)(max_current_ac_target*10);
-                        if(max_current_ac_target_i > 32767) {max_current_ac_target_i = 32767;
-                        } else if(max_current_ac_target_i < -32768) {max_current_ac_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_current_ac_target_i) & 0xFFFFULL) << 48;
-            
-            uint64_t data_bigendian = __builtin_bswap64(data);
-            memcpy(msg.data, &data_bigendian, 8);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_ac_brake_current_command
-(float max_ac_brake_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x136;
-    msg.id_is_extended = false;
-    
-            uint64_t data = 0;
-            msg.len = 8;
-                        int32_t max_ac_brake_current_target_i = (int32_t)(max_ac_brake_current_target*10);
-                        if(max_ac_brake_current_target_i > 32767) {max_ac_brake_current_target_i = 32767;
-                        } else if(max_ac_brake_current_target_i < -32768) {max_ac_brake_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_ac_brake_current_target_i) & 0xFFFFULL) << 48;
-            
-            uint64_t data_bigendian = __builtin_bswap64(data);
-            memcpy(msg.data, &data_bigendian, 8);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_dc_current_command
-(float max_dc_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x156;
-    msg.id_is_extended = false;
-    
-            uint16_t data = 0;
-            msg.len = 2;
-                        int32_t max_dc_current_target_i = (int32_t)(max_dc_current_target*10);
-                        if(max_dc_current_target_i > 32767) {max_dc_current_target_i = 32767;
-                        } else if(max_dc_current_target_i < -32768) {max_dc_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_dc_current_target_i) & 0xFFFFULL) << 0;
-            
-            uint16_t data_bigendian = __builtin_bswap16(data);
-            memcpy(msg.data, &data_bigendian, 2);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_dc_brake_current_command
-(float max_dc_brake_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x176;
-    msg.id_is_extended = false;
-    
-            uint16_t data = 0;
-            msg.len = 2;
-                        int32_t max_dc_brake_current_target_i = (int32_t)(max_dc_brake_current_target*10);
-                        if(max_dc_brake_current_target_i > 32767) {max_dc_brake_current_target_i = 32767;
-                        } else if(max_dc_brake_current_target_i < -32768) {max_dc_brake_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_dc_brake_current_target_i) & 0xFFFFULL) << 0;
-            
-            uint16_t data_bigendian = __builtin_bswap16(data);
-            memcpy(msg.data, &data_bigendian, 2);
 
     return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
 }

--- a/Core/Src/can_messages_tx.c
+++ b/Core/Src/can_messages_tx.c
@@ -16,90 +16,6 @@
 static void handle_bitstream_overflow(bitstream_t *bitstream_res,
 					    uint32_t can_id);
 
-uint8_t send_max_ac_current_command
-(float max_current_ac_target)
-{
-    can_msg_t msg;
-    msg.id = 0x116;
-    msg.id_is_extended = false;
-    
-            uint64_t data = 0;
-            msg.len = 8;
-                        int32_t max_current_ac_target_i = (int32_t)(max_current_ac_target*10);
-                        if(max_current_ac_target_i > 32767) {max_current_ac_target_i = 32767;
-                        } else if(max_current_ac_target_i < -32768) {max_current_ac_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_current_ac_target_i) & 0xFFFFULL) << 48;
-            
-            uint64_t data_bigendian = __builtin_bswap64(data);
-            memcpy(msg.data, &data_bigendian, 8);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_ac_brake_current_command
-(float max_ac_brake_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x136;
-    msg.id_is_extended = false;
-    
-            uint64_t data = 0;
-            msg.len = 8;
-                        int32_t max_ac_brake_current_target_i = (int32_t)(max_ac_brake_current_target*10);
-                        if(max_ac_brake_current_target_i > 32767) {max_ac_brake_current_target_i = 32767;
-                        } else if(max_ac_brake_current_target_i < -32768) {max_ac_brake_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_ac_brake_current_target_i) & 0xFFFFULL) << 48;
-            
-            uint64_t data_bigendian = __builtin_bswap64(data);
-            memcpy(msg.data, &data_bigendian, 8);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_dc_current_command
-(float max_dc_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x156;
-    msg.id_is_extended = false;
-    
-            uint16_t data = 0;
-            msg.len = 2;
-                        int32_t max_dc_current_target_i = (int32_t)(max_dc_current_target*10);
-                        if(max_dc_current_target_i > 32767) {max_dc_current_target_i = 32767;
-                        } else if(max_dc_current_target_i < -32768) {max_dc_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_dc_current_target_i) & 0xFFFFULL) << 0;
-            
-            uint16_t data_bigendian = __builtin_bswap16(data);
-            memcpy(msg.data, &data_bigendian, 2);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
-uint8_t send_max_dc_brake_current_command
-(float max_dc_brake_current_target)
-{
-    can_msg_t msg;
-    msg.id = 0x176;
-    msg.id_is_extended = false;
-    
-            uint16_t data = 0;
-            msg.len = 2;
-                        int32_t max_dc_brake_current_target_i = (int32_t)(max_dc_brake_current_target*10);
-                        if(max_dc_brake_current_target_i > 32767) {max_dc_brake_current_target_i = 32767;
-                        } else if(max_dc_brake_current_target_i < -32768) {max_dc_brake_current_target_i = -32768;
-                        }
-                        data |= ((uint32_t)(max_dc_brake_current_target_i) & 0xFFFFULL) << 0;
-            
-            uint16_t data_bigendian = __builtin_bswap16(data);
-            memcpy(msg.data, &data_bigendian, 2);
-
-    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
-}
-
 uint8_t send_bms_status
 (uint8_t state,float temp_average)
 {
@@ -1403,20 +1319,41 @@ uint8_t send_pack_soc_status
 }
 
 uint8_t send_shutdown_as_read_by_bms
-(bool shutdown)
+(bool shutdown,bool ts_minus_sense,bool ts_plus_sense,bool acc_sense,bool tsip_sense)
 {
     can_msg_t msg;
     msg.id = 0x95;
     msg.id_is_extended = false;
     
-            uint8_t data = 0;
-            msg.len = 1;
+            uint64_t data = 0;
+            msg.len = 8;
                         uint32_t shutdown_i = (uint32_t)(shutdown);
                         if(shutdown_i > 255ULL) {shutdown_i = 255;
                         }
-                        data |= ((shutdown_i) & 0xFFULL) << 0;
+                        data |= ((shutdown_i) & 0xFFULL) << 56;
             
-            msg.data[0] = data;
+                        uint32_t ts_minus_sense_i = (uint32_t)(ts_minus_sense);
+                        if(ts_minus_sense_i > 255ULL) {ts_minus_sense_i = 255;
+                        }
+                        data |= ((ts_minus_sense_i) & 0xFFULL) << 48;
+            
+                        uint32_t ts_plus_sense_i = (uint32_t)(ts_plus_sense);
+                        if(ts_plus_sense_i > 255ULL) {ts_plus_sense_i = 255;
+                        }
+                        data |= ((ts_plus_sense_i) & 0xFFULL) << 40;
+            
+                        uint32_t acc_sense_i = (uint32_t)(acc_sense);
+                        if(acc_sense_i > 255ULL) {acc_sense_i = 255;
+                        }
+                        data |= ((acc_sense_i) & 0xFFULL) << 32;
+            
+                        uint32_t tsip_sense_i = (uint32_t)(tsip_sense);
+                        if(tsip_sense_i > 255ULL) {tsip_sense_i = 255;
+                        }
+                        data |= ((tsip_sense_i) & 0xFFULL) << 24;
+            
+            uint64_t data_bigendian = __builtin_bswap64(data);
+            memcpy(msg.data, &data_bigendian, 8);
 
     return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
 }
@@ -1455,9 +1392,8 @@ uint8_t send_bms_critically_faulted
 (bool critically_faulted)
 {
     can_msg_t msg;
-    msg.id = 0x096;
-    msg.id_is_extended = false;
-    
+    msg.id = 0x01E;
+    msg.id_is_extended = true;
             uint8_t data = 0;
             msg.len = 1;
                         uint32_t critically_faulted_i = (uint32_t)(critically_faulted);
@@ -1495,6 +1431,90 @@ uint8_t send_bms_charge_message_send
             
             uint64_t data_bigendian = __builtin_bswap64(data);
             memcpy(msg.data, &data_bigendian, 8);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_ac_current_command
+(float max_current_ac_target)
+{
+    can_msg_t msg;
+    msg.id = 0x116;
+    msg.id_is_extended = false;
+    
+            uint64_t data = 0;
+            msg.len = 8;
+                        int32_t max_current_ac_target_i = (int32_t)(max_current_ac_target*10);
+                        if(max_current_ac_target_i > 32767) {max_current_ac_target_i = 32767;
+                        } else if(max_current_ac_target_i < -32768) {max_current_ac_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_current_ac_target_i) & 0xFFFFULL) << 48;
+            
+            uint64_t data_bigendian = __builtin_bswap64(data);
+            memcpy(msg.data, &data_bigendian, 8);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_ac_brake_current_command
+(float max_ac_brake_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x136;
+    msg.id_is_extended = false;
+    
+            uint64_t data = 0;
+            msg.len = 8;
+                        int32_t max_ac_brake_current_target_i = (int32_t)(max_ac_brake_current_target*10);
+                        if(max_ac_brake_current_target_i > 32767) {max_ac_brake_current_target_i = 32767;
+                        } else if(max_ac_brake_current_target_i < -32768) {max_ac_brake_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_ac_brake_current_target_i) & 0xFFFFULL) << 48;
+            
+            uint64_t data_bigendian = __builtin_bswap64(data);
+            memcpy(msg.data, &data_bigendian, 8);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_dc_current_command
+(float max_dc_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x156;
+    msg.id_is_extended = false;
+    
+            uint16_t data = 0;
+            msg.len = 2;
+                        int32_t max_dc_current_target_i = (int32_t)(max_dc_current_target*10);
+                        if(max_dc_current_target_i > 32767) {max_dc_current_target_i = 32767;
+                        } else if(max_dc_current_target_i < -32768) {max_dc_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_dc_current_target_i) & 0xFFFFULL) << 0;
+            
+            uint16_t data_bigendian = __builtin_bswap16(data);
+            memcpy(msg.data, &data_bigendian, 2);
+
+    return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
+}
+
+uint8_t send_max_dc_brake_current_command
+(float max_dc_brake_current_target)
+{
+    can_msg_t msg;
+    msg.id = 0x176;
+    msg.id_is_extended = false;
+    
+            uint16_t data = 0;
+            msg.len = 2;
+                        int32_t max_dc_brake_current_target_i = (int32_t)(max_dc_brake_current_target*10);
+                        if(max_dc_brake_current_target_i > 32767) {max_dc_brake_current_target_i = 32767;
+                        } else if(max_dc_brake_current_target_i < -32768) {max_dc_brake_current_target_i = -32768;
+                        }
+                        data |= ((uint32_t)(max_dc_brake_current_target_i) & 0xFFFFULL) << 0;
+            
+            uint16_t data_bigendian = __builtin_bswap16(data);
+            memcpy(msg.data, &data_bigendian, 2);
 
     return queue_send(&can_outgoing, &msg, TX_NO_WAIT);
 }

--- a/Core/Src/compute.c
+++ b/Core/Src/compute.c
@@ -371,7 +371,8 @@ static void set_shutdown_active(void *arg)
 	mutex_get(&shutdown_mutex);
 	peripherals->shutdown_active = true;
 	mutex_put(&shutdown_mutex);
-	send_shutdown_as_read_by_bms(true);
+	send_shutdown_as_read_by_bms(true, read_shutdown_ts_minus_sense(), read_shutdown_ts_plus_sense(),
+				   read_shutdown_acc_sense(), read_shutdown_tsip_sense());
 }
 
 static void set_shutdown_inactive(void *arg)
@@ -386,7 +387,25 @@ static void set_shutdown_inactive(void *arg)
 	mutex_get(&shutdown_mutex);
 	peripherals->shutdown_active = false;
 	mutex_put(&shutdown_mutex);
-	send_shutdown_as_read_by_bms(false);
+	send_shutdown_as_read_by_bms(false, read_shutdown_ts_minus_sense(), read_shutdown_ts_plus_sense(),
+				   read_shutdown_acc_sense(), read_shutdown_tsip_sense());
+}
+
+bool read_shutdown_ts_minus_sense(void)
+{
+	return HAL_GPIO_ReadPin(TS_MINUS_SENSE_GPIO_Port, TS_MINUS_SENSE_Pin);
+}
+bool read_shutdown_ts_plus_sense(void)
+{
+	return HAL_GPIO_ReadPin(TS_PLUS_SENSE_GPIO_Port, TS_PLUS_SENSE_Pin);
+}
+bool read_shutdown_acc_sense(void)
+{
+	return HAL_GPIO_ReadPin(ACC_SENSE_GPIO_Port, ACC_SENSE_Pin);
+}
+bool read_shutdown_tsip_sense(void)
+{
+	return HAL_GPIO_ReadPin(TSIP_SENSE_GPIO_Port, TSIP_SENSE_Pin);
 }
 
 void read_shutdown(peripherals_t *peripherals)
@@ -397,11 +416,10 @@ void read_shutdown(peripherals_t *peripherals)
 
 	// Read shutdown sense using TS_MINUS_SENSE pin
 	bool shutdown_inactive =
-		HAL_GPIO_ReadPin(TS_MINUS_SENSE_GPIO_Port,
-				 TS_MINUS_SENSE_Pin) &&
-		HAL_GPIO_ReadPin(TS_PLUS_SENSE_GPIO_Port, TS_PLUS_SENSE_Pin) &&
-		HAL_GPIO_ReadPin(ACC_SENSE_GPIO_Port, ACC_SENSE_Pin) &&
-		HAL_GPIO_ReadPin(TSIP_SENSE_GPIO_Port, TSIP_SENSE_Pin);
+		read_shutdown_ts_minus_sense() &&
+		read_shutdown_ts_plus_sense() &&
+		read_shutdown_acc_sense() &&
+		read_shutdown_tsip_sense();
 
 	debounce(!shutdown_inactive, &shutdown_active_timer, debounce_time,
 		 set_shutdown_active, peripherals);
@@ -482,7 +500,8 @@ void vPeripherals(ULONG thread_input)
 			// send shutdown state periodically
 
 			send_shutdown_as_read_by_bms(
-				peripherals->shutdown_active);
+				peripherals->shutdown_active, read_shutdown_ts_minus_sense(), read_shutdown_ts_plus_sense(),
+				read_shutdown_acc_sense(), read_shutdown_tsip_sense());
 
 			mutex_get(&peripherals_mutex);
 			send_bms_onboard_temperature(peripherals->onboard_temp);


### PR DESCRIPTION
## Changes

Added individual GPIO shutdown states to CAN mssg 0x95. Initially, only the combined shutdown boolean was sent, now each GPIO is sent individually for diagnostics. Updated bms.json in Odyssey-definitions, used ner-cgen cmmd to make new can_messages_tx files and updated send_shutdown_as_read_by_bms function to have more booleans.


## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [ ] No merge conflicts
- [ ] All checks passing
- [ ] Remove any non-applicable sections of this template
- [ ] Assign the PR to yourself
- [ ] Request reviewers & ping on Slack
- [ ] PR is linked to the ticket (fill in the closes line below)

Closes # (issue #)
