### PR TITLE
Fix HV Plate PEC

### DIFF
--- a/Core/Inc/shep_mutexes.h
+++ b/Core/Inc/shep_mutexes.h
@@ -13,6 +13,7 @@ extern mutex_t state_mutex;
 extern mutex_t bms_algos_mutex;
 extern mutex_t peripherals_mutex; 
 extern mutex_t shutdown_mutex; 
+extern mutex_t hv_plate_comms_mutex;
 // add more as necessary...
 
 /* API */

--- a/Core/Src/hv_plate.c
+++ b/Core/Src/hv_plate.c
@@ -189,7 +189,9 @@ void vHvPlateData(ULONG thread_input)
 	ccl_init(COOLDOWN_ALWAYS);
 
 	// initialize HV Plate struct and start conversions
+	mutex_get(&hv_plate_comms_mutex);
 	init_hv_plate(hv_plate, ACCI_8);
+	mutex_put(&hv_plate_comms_mutex);
 
 	hv_plate_isospi_break_detection_init(&hv_plate->ic);
 
@@ -197,17 +199,35 @@ void vHvPlateData(ULONG thread_input)
 
 	start_timer(&diagnostic_read_timer, diagnostic_read_frequency);
 
+	mutex_get(&hv_plate_comms_mutex);
 	// initialize precharge relay open
-	reset_gpo(&hv_plate->ic, HV_CTRL_GPO); 
-
-	soc_init();
+	reset_gpo(&hv_plate->ic, HV_CTRL_GPO);
 
 	// enable reading HV
 	set_gpo(&hv_plate->ic, HV_ENABLE_GPO);
+	mutex_put(&hv_plate_comms_mutex);
+
+	soc_init();
 
 	for (;;) {
-		// get the current reading from the pack
+		const bool diagnostic_read_required =
+			is_timer_expired(&diagnostic_read_timer) &&
+			!is_timer_active(&diagnostic_read_timer);
+
+		// Keep all HV plate communication in one protected window.
+		mutex_get(&hv_plate_comms_mutex);
 		get_pack_current_and_batt_voltage(hv_plate);
+		get_ts_voltage(hv_plate);
+		get_shunt_temp(hv_plate);
+
+		if (diagnostic_read_required) {
+			get_aux_adc_data(hv_plate);
+			get_flags(hv_plate);
+		}
+
+		send_hv_plate_pec_errors_message();
+		hv_plate_isospi_handle_state(hv_plate, state_machine);
+		mutex_put(&hv_plate_comms_mutex);
 
 		hv_plate->batt_volts = analyzer->pack_voltage;
 
@@ -228,16 +248,7 @@ void vHvPlateData(ULONG thread_input)
 			ccl_calc_cont_limit(hv_plate->pack_current, bms_algos);
 		}
 
-		// read ts voltage
-		get_ts_voltage(hv_plate);
-
-		// read shunt temperature
-		get_shunt_temp(hv_plate);
-
-		if (is_timer_expired(&diagnostic_read_timer) &&
-		    !is_timer_active(&diagnostic_read_timer)) {
-			get_aux_adc_data(hv_plate);
-
+		if (diagnostic_read_required) {
 			// send hv plate data for telemetry
 			PRINTLN_INFO("Sending HV Plate Data...");
 			send_hv_plate_voltages(hv_plate->batt_volts,
@@ -252,8 +263,6 @@ void vHvPlateData(ULONG thread_input)
 			send_pack_current_and_shunt_temp(hv_plate->pack_current, 
 				hv_plate->shunt_temp);
 
-			// read flags
-			get_flags(hv_plate);
 			start_timer(&diagnostic_read_timer,
 				    diagnostic_read_frequency);
 
@@ -267,9 +276,6 @@ void vHvPlateData(ULONG thread_input)
 				hv_plate->epad, hv_plate->vdig, hv_plate->vdd,
 				hv_plate->tmp2, hv_plate->vdiv);
 		}
-
-		send_hv_plate_pec_errors_message();
-		hv_plate_isospi_handle_state(hv_plate, state_machine);
 
 		mutex_get(&state_mutex);
 		bms_state = state_machine->bms_state;

--- a/Core/Src/precharge_routine.c
+++ b/Core/Src/precharge_routine.c
@@ -1,6 +1,7 @@
 #include "precharge_routine.h"
 #include <assert.h>
 #include "debounce.h"
+#include "shep_mutexes.h"
 
 #define MINIMUM_PACK_VOLTAGE 200.0f
 
@@ -24,11 +25,15 @@ static sample_buffer_t batt_volts_sample_buffer = { 0 };
 
 static void set_precharge_relay(cell_asic_2950 *ic, bool state)
 {
+	mutex_get(&hv_plate_comms_mutex);
+
 	if (state) {
 		set_gpo(ic, HV_CTRL_GPO);
 	} else {
 		reset_gpo(ic, HV_CTRL_GPO);
 	}
+
+	mutex_put(&hv_plate_comms_mutex);
 }
 
 static void close_relay(void *args)

--- a/Core/Src/shep_mutexes.c
+++ b/Core/Src/shep_mutexes.c
@@ -27,6 +27,11 @@ mutex_t shutdown_mutex = {
 	.priority_inherit = TX_INHERIT /* Priority inheritance setting. */
 };
 
+mutex_t hv_plate_comms_mutex = {
+	.name = "HV Plate Comms Mutex", /* Name of the mutex. */
+	.priority_inherit = TX_INHERIT /* Priority inheritance setting. */
+};
+
 
 /* Initializes all ThreadX mutexes. 
 *  Calls to _create_mutex() should go in here
@@ -39,6 +44,7 @@ uint8_t mutexes_init()
 	CATCH_ERROR(create_mutex(&bms_algos_mutex), U_SUCCESS);
 	CATCH_ERROR(create_mutex(&peripherals_mutex), U_SUCCESS);
 	CATCH_ERROR(create_mutex(&shutdown_mutex), U_SUCCESS);
+	CATCH_ERROR(create_mutex(&hv_plate_comms_mutex), U_SUCCESS);
 
 	// add more as necessary.
 


### PR DESCRIPTION
## Changes

- Fixed hv plate pec issue.
- Issue was a race condition between hv plate and precharge task for adbms2950 comms fixed with a mutex around read sections.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
