### PR TITLE
Service VCU BMS CAN-monitor watchdog in faulted state

### DIFF
--- a/Core/Src/hv_plate.c
+++ b/Core/Src/hv_plate.c
@@ -288,6 +288,8 @@ void vHvPlateData(ULONG thread_input)
 			max_dc_brake_current = (-1.0f * bms_algos->cont_CCL);
 			mutex_put(&bms_algos_mutex);
 
+			// The max DC current command is used by the DTI to limit discharge current and
+			// by the VCU to reset the BMS CAN-monitor watchdog.
 			send_max_dc_current_command(max_dc_current);
 			send_max_dc_brake_current_command(max_dc_brake_current);
 		}

--- a/Core/Src/hv_plate.c
+++ b/Core/Src/hv_plate.c
@@ -288,8 +288,6 @@ void vHvPlateData(ULONG thread_input)
 			max_dc_brake_current = (-1.0f * bms_algos->cont_CCL);
 			mutex_put(&bms_algos_mutex);
 
-			// The max DC current command is used by the DTI to limit discharge current and
-			// by the VCU to reset the BMS CAN-monitor watchdog.
 			send_max_dc_current_command(max_dc_current);
 			send_max_dc_brake_current_command(max_dc_brake_current);
 		}

--- a/Core/Src/state_machine.c
+++ b/Core/Src/state_machine.c
@@ -143,7 +143,8 @@ void handle_charging(state_machine_args_t *state_machine_args)
 		send_bms_charge_message_send(0, 0, 0xFF);
 	}
 
-	// disable discharge and charge from the MC
+	// Disable discharge and charge from the MC.
+	// The max DC current command also resets the BMS CAN-monitor watchdog on VCU.
 	send_max_dc_current_command(0);
 	send_max_dc_brake_current_command(0);
 
@@ -176,6 +177,10 @@ void init_faulted(state_machine_args_t *state_machine_args)
 void handle_faulted(state_machine_args_t *state_machine_args)
 {
 	compute_set_fault(true);
+	// Disable discharge and charge from the MC.
+	// The max DC current command also resets the BMS CAN-monitor watchdog on VCU.
+	send_max_dc_current_command(0);
+	send_max_dc_brake_current_command(0);
 	// leave faulted if all is well
 	if (!are_critical_faults_active()) {
 		request_transition(state_machine_args, BOOT);

--- a/Tests/Src/test_statemachine.c
+++ b/Tests/Src/test_statemachine.c
@@ -146,6 +146,7 @@ void test_handle_faulted_sends_zero_current_limits(void)
 	send_max_dc_brake_current_command_ExpectAndReturn(0.0f, 0U);
 
 	handle_faulted(&args);
+	mock_can_messages_tx_Verify();
 }
 
 void test_handle_charging_sends_zero_current_limits(void)
@@ -160,6 +161,7 @@ void test_handle_charging_sends_zero_current_limits(void)
 	send_max_dc_brake_current_command_ExpectAndReturn(0.0f, 0U);
 
 	handle_charging(&args);
+	mock_can_messages_tx_Verify();
 }
 
 void test_balancing(void)

--- a/Tests/Src/test_statemachine.c
+++ b/Tests/Src/test_statemachine.c
@@ -5,6 +5,7 @@
 #include "mock_u_tx_mutex.h"
 #include "mock_timer.h"
 #include "mock_can_messages_tx.h"
+#include "mock_compute.h"
 
 state_machine_t state_machine;
 analyzer_t analyzer;
@@ -138,6 +139,29 @@ void test_charge_fault(void)
 	TEST_ASSERT_EQUAL(CHARGING, state_machine.bms_state);
 }
 
+void test_handle_faulted_sends_zero_current_limits(void)
+{
+	compute_set_fault_Expect(true);
+	send_max_dc_current_command_ExpectAndReturn(0.0f, 0U);
+	send_max_dc_brake_current_command_ExpectAndReturn(0.0f, 0U);
+
+	handle_faulted(&args);
+}
+
+void test_handle_charging_sends_zero_current_limits(void)
+{
+	state_machine.bms_state = CHARGING;
+	state_machine.charging_stage = LONG_SETTLE;
+
+	is_timer_expired_ExpectAndReturn(&state_machine.charging_stage_timer,
+					false);
+	send_bms_charge_message_send_ExpectAndReturn(0.0f, 0.0f, 0xFFU, 0U);
+	send_max_dc_current_command_ExpectAndReturn(0.0f, 0U);
+	send_max_dc_brake_current_command_ExpectAndReturn(0.0f, 0U);
+
+	handle_charging(&args);
+}
+
 void test_balancing(void)
 {
 	// Balancing allowed
@@ -178,6 +202,8 @@ int main(void)
 	RUN_TEST(test_short_charge_cycle);
 	RUN_TEST(test_charge_done);
 	RUN_TEST(test_charge_fault);
+	RUN_TEST(test_handle_faulted_sends_zero_current_limits);
+	RUN_TEST(test_handle_charging_sends_zero_current_limits);
 	RUN_TEST(test_balancing);
 
 	return UNITY_END();


### PR DESCRIPTION
## Changes

- Send zero charge and discharge current limits while charging or faulted.
- Add unit tests verifying the zero current-limit commands are sent in both states.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
