### PR TITLE
Clear balancing PWM when disabled

### DIFF
--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -229,6 +229,7 @@ void segment_disable_balancing(cell_asic chips[NUM_CHIPS],
 	// Initializes all array elements to zero
 	PWM_DUTY discharge_config[NUM_CHIPS][NUM_CELLS_PER_CHIP] = { 0 };
 	segment_configure_balancing(chips, discharge_config, hspi);
+	segment_read_pwm_registers(chips, hspi);
 }
 
 void segment_enable_balancing(cell_asic chips[NUM_CHIPS],

--- a/Core/Src/segment.c
+++ b/Core/Src/segment.c
@@ -223,12 +223,12 @@ bool segment_is_balancing(cell_asic chips[NUM_CHIPS])
 void segment_disable_balancing(cell_asic chips[NUM_CHIPS],
 			       SPI_HandleTypeDef *hspi)
 {
+	// Stop balancing before clearing the PWM configuration.
+	mute_chips(chips, hspi);
+
 	// Initializes all array elements to zero
 	PWM_DUTY discharge_config[NUM_CHIPS][NUM_CELLS_PER_CHIP] = { 0 };
 	segment_configure_balancing(chips, discharge_config, hspi);
-
-	// force balancing muted
-	mute_chips(chips, hspi);
 }
 
 void segment_enable_balancing(cell_asic chips[NUM_CHIPS],
@@ -429,7 +429,7 @@ void vGetSegmentData(ULONG thread_input)
 
 		if ((prev_state != current_state && !charging) ||
 		    (prev_balancing_active && !balancing_active)) {
-			segment_mute(acc_data->chips, &hspi2);
+			segment_disable_balancing(acc_data->chips, &hspi2);
 		}
 
 		if (charging) {


### PR DESCRIPTION
## Changes

- Currently, during the LONG_SETTLE and SHORT_SETTLE charging stages, the balancing duty cycle is not reset to zero, causing Argos to incorrectly show cells as balancing. This change clears the balancing configuration during settling so telemetry accurately reflects that balancing is disabled.

## Checklist

It can be helpful to check the `Checks` and `Files changed` tabs.
Please reach out to your Project Lead if anything is unclear.
Please request reviewers and ping on slack only after you've gone through this whole checklist.

- [x] No merge conflicts
- [x] All checks passing
- [x] Remove any non-applicable sections of this template
- [x] Assign the PR to yourself
- [x] Request reviewers & ping on Slack
